### PR TITLE
Disable admin when request contains the configured disable header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ subprojects {
     
     dependencies {
         testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+        testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
         testCompile group: 'org.assertj', name: 'assertj-core', version: versions.assertj
         testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
     }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
@@ -81,12 +81,18 @@ class AdminRouteProperties {
     var pathPrefix = "/status/envoy"
     var token = ""
     var securedPaths: MutableList<SecuredRoute> = ArrayList()
+    var disable = AdminDisableProperties()
 }
 
 class StatusRouteProperties {
     var enabled = false
     var pathPrefix = "/status/"
     var createVirtualCluster = false
+}
+
+class AdminDisableProperties {
+    var onHeader = ""
+    var responseCode = 403
 }
 
 class LocalServiceProperties {

--- a/envoy-control-tests/build.gradle
+++ b/envoy-control-tests/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     compile group: 'org.assertj', name: 'assertj-core', version: versions.assertj
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+    compile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
     compile group: 'org.awaitility', name: 'awaitility', version: versions.awaitility
     compile(group: 'com.pszymczyk.consul', name: 'embedded-consul', version: versions.embedded_consul) {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/AdminRouteTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/AdminRouteTest.kt
@@ -3,12 +3,18 @@ package pl.allegro.tech.servicemesh.envoycontrol
 import okhttp3.Headers
 import okhttp3.MediaType
 import okhttp3.RequestBody
+import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlRunnerTestApp
 import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.SecuredRoute
+import java.util.stream.Stream
 
 internal class AdminRouteTest : EnvoyControlTestConfiguration() {
     companion object {
@@ -17,6 +23,7 @@ internal class AdminRouteTest : EnvoyControlTestConfiguration() {
             "envoy-control.envoy.snapshot.routes.admin.publicAccessEnabled" to true,
             "envoy-control.envoy.snapshot.routes.admin.path-prefix" to "/status/envoy",
             "envoy-control.envoy.snapshot.routes.admin.token" to "admin_secret_token",
+            "envoy-control.envoy.snapshot.routes.admin.disable.on-header" to "to-disable",
             "envoy-control.envoy.snapshot.routes.admin.securedPaths" to listOf(
                 SecuredRoute().apply {
                     pathPrefix = "/config_dump"
@@ -30,13 +37,67 @@ internal class AdminRouteTest : EnvoyControlTestConfiguration() {
         fun setupAdminRoutesTest() {
             setup(appFactoryForEc1 = { consulPort -> EnvoyControlRunnerTestApp(properties, consulPort) })
         }
+
+        @BeforeEach
+        fun stopLocalService() {
+            localServiceContainer.stop()
+        }
+
+        @JvmStatic
+        fun disableOnHeaderTestCases(): Stream<Arguments> {
+            val disableHeader = "to-disable" to ""
+
+            return Stream.of(
+                    Arguments.of("admin root", {
+                        callLocalService(
+                                endpoint = "/status/envoy/",
+                                headers = Headers.of(mapOf(disableHeader))
+                        )
+                    }),
+                    Arguments.of("admin root without trailing slash", {
+                        callLocalService(
+                                endpoint = "/status/envoy",
+                                headers = Headers.of(mapOf(disableHeader))
+                        )
+                    }),
+                    Arguments.of("clusters", {
+                        callLocalService(
+                                endpoint = "/status/envoy/clusters",
+                                headers = Headers.of(mapOf(disableHeader))
+                        )
+                    }),
+                    Arguments.of("config dump as unauthorized", {
+                        callLocalService(
+                                endpoint = "/status/envoy/config_dump",
+                                headers = Headers.of(mapOf(disableHeader))
+                        )
+                    }),
+                    Arguments.of("config dump as authorized", {
+                        callLocalService(
+                                endpoint = "/status/envoy/config_dump",
+                                headers = Headers.of(mapOf(disableHeader, "authorization" to "admin_secret_token"))
+                        )
+                    }),
+                    Arguments.of("reset counters as unauthorized", {
+                        callPostLocalService(
+                                endpoint = "/status/envoy/reset_counters",
+                                headers = Headers.of(mapOf(disableHeader)),
+                                body = RequestBody.create(MediaType.get("application/json"), "{}")
+                        )
+                    }),
+                    Arguments.of("reset counters as authorized", {
+                        callPostLocalService(
+                                endpoint = "/status/envoy/reset_counters",
+                                headers = Headers.of(mapOf(disableHeader, "authorization" to "admin_secret_token")),
+                                body = RequestBody.create(MediaType.get("application/json"), "{}")
+                        )
+                    })
+            )
+        }
     }
 
     @Test
     fun `should get admin redirected port on ingress port when enabled`() {
-        // given
-        localServiceContainer.stop()
-
         // when
         val response = callLocalService(endpoint = "/status/envoy", headers = Headers.of(emptyMap()))
 
@@ -46,9 +107,6 @@ internal class AdminRouteTest : EnvoyControlTestConfiguration() {
 
     @Test
     fun `should get access to secured endpoints when authorized only`() {
-        // given
-        localServiceContainer.stop()
-
         // when
         val configDumpResponseUnauthorized = callLocalService(
             endpoint = "/status/envoy/config_dump",
@@ -74,5 +132,15 @@ internal class AdminRouteTest : EnvoyControlTestConfiguration() {
         assertThat(configDumpResponseAuthorized.isSuccessful).isTrue()
         assertThat(resetCountersResponseUnauthorized.code()).isEqualTo(401)
         assertThat(resetCountersResponseAuthorized.isSuccessful).isTrue()
+    }
+
+    @ParameterizedTest
+    @MethodSource("disableOnHeaderTestCases")
+    fun `should block access to all admin endpoints when request contains the disable header`(
+            caseDescription: String,
+            request: () -> Response
+    ) {
+        // expect
+        assertThat(request.invoke().code()).describedAs(caseDescription).isEqualTo(403)
     }
 }


### PR DESCRIPTION
Adds a new, optional mechanism for securing Envoy admin. When `envoy-control.envoy.snapshot.routes.admin.disable.on-header` is set to X, all requests with header X present will be denied access to admin routes. Access is denied by sending an immediate response with status code configured under `envoy-control.envoy.snapshot.routes.admin.disable.response-code`, by default `403`.

No docs for this change since there are no docs for admin routes at all.