### PR TITLE
Set tag for docker envoy-alpine instead of lastest

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
@@ -47,7 +47,7 @@ internal class EnvoySnapshotFactory(
                 toClusterConfiguration(instances, serviceName)
             }
         } else {
-            serviceNames.map { ClusterConfiguration(serviceName = it, http2Enabled = false)}
+            serviceNames.map { ClusterConfiguration(serviceName = it, http2Enabled = false) }
         }
 
         val clusters = clustersFactory.getClustersForServices(clusterConfigurations, ads)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/AdminRouteTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/AdminRouteTest.kt
@@ -137,8 +137,8 @@ internal class AdminRouteTest : EnvoyControlTestConfiguration() {
     @ParameterizedTest
     @MethodSource("disableOnHeaderTestCases")
     fun `should block access to all admin endpoints when request contains the disable header`(
-            caseDescription: String,
-            request: () -> Response
+        caseDescription: String,
+        request: () -> Response
     ) {
         // expect
         assertThat(request.invoke().code()).describedAs(caseDescription).isEqualTo(403)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
@@ -305,5 +305,4 @@ abstract class EnvoyControlTestConfiguration : BaseEnvoyTest() {
         }
         waitForConsulSync()
     }
-
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
@@ -13,10 +13,7 @@ class EnvoyContainer(
     private val envoyControl1XdsPort: Int,
     private val envoyControl2XdsPort: Int = envoyControl1XdsPort
 ) : GenericContainer<EnvoyContainer>(ImageFromDockerfile().withDockerfileFromBuilder {
-    it.from("envoyproxy/envoy-alpine:latest") // TODO (https://github.com/allegro/envoy-control/issues/7): NOT latest,
-            // whatever is tagged latest in local cache is considered latest, C'MON
-            // this should be possible to overcome soon: https://github.com/moby/moby/issues/13331
-            // but it's not great in the long run if future updates break the build
+    it.from("envoyproxy/envoy-alpine:v1.11.2")
         .run("apk --no-cache add curl iproute2")
         .build()
 }) {


### PR DESCRIPTION
Accordingly to https://github.com/allegro/envoy-control/issues/7.
Apart from https://github.com/envoyproxy/envoy/blob/master/ci/README.md#alpine-envoy-image I haven't found any semantics of envoy-alpine tags so I've just chosen the latest available, non hash, tag.

Also using `gradle build` ktlint found some formatting issues which I applied.

What's weird running gradle build in intellij without docker service running error messages which I received contained only "command failed" pointing to ktlint when in reality tests failed due missing docker.