### PR TITLE
Changed initial RDS version to random

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
@@ -47,7 +47,7 @@ internal class EnvoySnapshotFactory(
                 toClusterConfiguration(instances, serviceName)
             }
         } else {
-            serviceNames.map { ClusterConfiguration(serviceName = it, http2Enabled = false)}
+            serviceNames.map { ClusterConfiguration(serviceName = it, http2Enabled = false) }
         }
 
         val clusters = clustersFactory.getClustersForServices(clusterConfigurations, ads)

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotsVersions.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotsVersions.kt
@@ -80,7 +80,7 @@ data class EndpointsVersion(val value: String) {
 
 data class RoutesVersion(val value: String) {
     companion object {
-        val EMPTY_VERSION = RoutesVersion("empty")
+        val EMPTY_VERSION = RoutesVersion(UUID.randomUUID().toString().replace("-", ""))
     }
 }
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
@@ -340,5 +340,4 @@ abstract class EnvoyControlTestConfiguration : BaseEnvoyTest() {
         }
         waitForConsulSync()
     }
-
 }


### PR DESCRIPTION
When EC is starting it should have random RDS version rather than `empty` because new routes will be sent only when Cluster change. Currently if we change something in ingress routes and deploy new version all envoys which don't have dependencies to clusters won't receive updates untill we restart them. This fix should update version each time new version of EC is deployed.