### PR TITLE
Added snapshot debugging endpoint

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ControlPlane.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ControlPlane.kt
@@ -2,6 +2,7 @@ package pl.allegro.tech.servicemesh.envoycontrol
 
 import io.envoyproxy.controlplane.cache.NodeGroup
 import io.envoyproxy.controlplane.cache.SimpleCache
+import io.envoyproxy.controlplane.cache.SnapshotCache
 import io.envoyproxy.controlplane.server.DefaultExecutorGroup
 import io.envoyproxy.controlplane.server.DiscoveryServer
 import io.envoyproxy.controlplane.server.ExecutorGroup
@@ -37,6 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger
 class ControlPlane private constructor(
     val grpcServer: Server,
     val snapshotUpdater: SnapshotUpdater,
+    val nodeGroup: NodeGroup<Group>,
+    val cache: SnapshotCache<Group>,
     private val changes: Flux<List<LocalityAwareServicesState>>
 ) : AutoCloseable {
 
@@ -155,6 +158,8 @@ class ControlPlane private constructor(
                     groupChangeWatcher.onGroupAdded(),
                     meterRegistry
                 ),
+                nodeGroup,
+                cache,
                 changes
             )
         }

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/infrastructure/ControlPlaneConfig.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/infrastructure/ControlPlaneConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.protobuf.ProtobufJsonFormatHttpMessageConverter
 import pl.allegro.tech.discovery.consul.recipes.ConsulRecipes
 import pl.allegro.tech.discovery.consul.recipes.datacenter.ConsulDatacenterReader
 import pl.allegro.tech.discovery.consul.recipes.json.JacksonJsonDeserializer
@@ -133,4 +134,9 @@ class ControlPlaneConfig {
             meterRegistry.gauge("cache.groupsCount", it.cacheGroupsCount)
             meterRegistry.more().counter("services.watch.errors", listOf(), it.errorWatchingServices)
         }
+
+    @Bean
+    fun protobufJsonFormatHttpMessageConverter(): ProtobufJsonFormatHttpMessageConverter {
+        return ProtobufJsonFormatHttpMessageConverter()
+    }
 }

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
@@ -1,0 +1,52 @@
+package pl.allegro.tech.servicemesh.envoycontrol.snapshot.debug
+
+import io.envoyproxy.controlplane.cache.NodeGroup
+import io.envoyproxy.controlplane.cache.Snapshot
+import io.envoyproxy.controlplane.cache.SnapshotCache
+import io.envoyproxy.envoy.api.v2.core.Node
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+import pl.allegro.tech.servicemesh.envoycontrol.ControlPlane
+import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
+
+@RestController
+class SnapshotDebugController(controlPlane: ControlPlane) {
+    val cache: SnapshotCache<Group> = controlPlane.cache
+    val nodeGroup: NodeGroup<Group> = controlPlane.nodeGroup
+
+    /**
+     * Returns a textual representation of the snapshot for debugging purposes.
+     * It contains the versions of XDS resources and the contents for a provided node JSON
+     * extracted from Envoy's config_dump endpoint. 
+     */
+    @PostMapping("/snapshot")
+    @ResponseBody
+    fun snapshot(@RequestBody node: Node): ResponseEntity<String> {
+        // TODO: handle missing snapshot (e.g. wrong data provided)
+        val nodeHash = nodeGroup.hash(node)
+        val snapshot = cache.getSnapshot(nodeHash)
+        if (snapshot == null) {
+            return ResponseEntity("snapshot missing", HttpStatus.NOT_FOUND)
+        }
+        return ResponseEntity(
+            versions(snapshot) +
+                "snapshot:\n" +
+                snapshot.toString(),
+            HttpStatus.OK
+        );
+    }
+
+    private fun versions(snapshot: Snapshot): String {
+        val versions = StringBuilder()
+            .append("clusters: ${snapshot.clusters().version()}\n")
+            .append("endpoints: ${snapshot.endpoints().version()}\n")
+            .append("routes: ${snapshot.routes().version()}\n")
+            .append("listeners: ${snapshot.listeners().version()}\n")
+        return versions.toString()
+    }
+
+}

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import pl.allegro.tech.servicemesh.envoycontrol.ControlPlane
 import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
@@ -24,20 +23,19 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
      * extracted from Envoy's config_dump endpoint.
      */
     @PostMapping("/snapshot")
-    @ResponseBody
     fun snapshot(@RequestBody node: Node): ResponseEntity<String> {
-        // TODO: handle missing snapshot (e.g. wrong data provided)
         val nodeHash = nodeGroup.hash(node)
         val snapshot = cache.getSnapshot(nodeHash)
-        if (snapshot == null) {
+        return if (snapshot == null) {
             return ResponseEntity("snapshot missing", HttpStatus.NOT_FOUND)
+        } else {
+            ResponseEntity(
+                versions(snapshot) +
+                    "snapshot:\n" +
+                    snapshot.toString(),
+                HttpStatus.OK
+            )
         }
-        return ResponseEntity(
-            versions(snapshot) +
-                "snapshot:\n" +
-                snapshot.toString(),
-            HttpStatus.OK
-        )
     }
 
     private fun versions(snapshot: Snapshot): String {

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
@@ -21,7 +21,7 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
     /**
      * Returns a textual representation of the snapshot for debugging purposes.
      * It contains the versions of XDS resources and the contents for a provided node JSON
-     * extracted from Envoy's config_dump endpoint. 
+     * extracted from Envoy's config_dump endpoint.
      */
     @PostMapping("/snapshot")
     @ResponseBody
@@ -37,7 +37,7 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
                 "snapshot:\n" +
                 snapshot.toString(),
             HttpStatus.OK
-        );
+        )
     }
 
     private fun versions(snapshot: Snapshot): String {
@@ -48,5 +48,4 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
             .append("listeners: ${snapshot.listeners().version()}\n")
         return versions.toString()
     }
-
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/SnapshotDebugTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/SnapshotDebugTest.kt
@@ -1,6 +1,6 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
@@ -16,7 +16,7 @@ open class SnapshotDebugTest : EnvoyControlTestConfiguration() {
     }
 
     @Test
-    open fun `getting snapshot debug info contains all information`() {
+    open fun `should return snapshot debug info containing snapshot versions`() {
         // given
         registerService(name = "echo")
         val nodeMetadata = envoyContainer1.admin().nodeInfo()
@@ -26,13 +26,28 @@ open class SnapshotDebugTest : EnvoyControlTestConfiguration() {
             val snapshot = envoyControl1.getSnapshot(nodeMetadata)
 
             // then
-            Assertions.assertThat(snapshot).isNotEmpty()
-            Assertions.assertThat(snapshot)
+            assertThat(snapshot).isNotEmpty()
+            assertThat(snapshot)
                 .contains("clusters: ")
                 .contains("endpoints: ")
                 .contains("routes: ")
                 .contains("listeners: ")
-            Assertions.assertThat(snapshot)
+        }
+    }
+
+    @Test
+    open fun `should return snapshot debug info containing snapshot contents`() {
+        // given
+        registerService(name = "echo")
+        val nodeMetadata = envoyContainer1.admin().nodeInfo()
+
+        untilAsserted {
+            // when
+            val snapshot = envoyControl1.getSnapshot(nodeMetadata)
+
+            // then
+            assertThat(snapshot).isNotEmpty()
+            assertThat(snapshot)
                 .contains("clusters=SnapshotResources")
                 .contains("endpoints=SnapshotResources")
                 .contains("routes=SnapshotResources")
@@ -40,7 +55,7 @@ open class SnapshotDebugTest : EnvoyControlTestConfiguration() {
         }
     }
 
-    val missingNodeJson = """{
+    private val missingNodeJson = """{
      "metadata": {
       "service_name": "service-mesh-service-first",
       "identity": "",
@@ -74,12 +89,12 @@ open class SnapshotDebugTest : EnvoyControlTestConfiguration() {
 """.trim()
 
     @Test
-    open fun `getting missing snapshot results returns valid description`() {
+    open fun `should inform about missing snapshot when given node does not exist`() {
         // when
         val snapshot = envoyControl1.getSnapshot(missingNodeJson)
 
         // then
-        Assertions.assertThat(snapshot).isNotEmpty()
-        Assertions.assertThat(snapshot).contains("snapshot missing")
+        assertThat(snapshot).isNotEmpty()
+        assertThat(snapshot).contains("snapshot missing")
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/SnapshotDebugTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/SnapshotDebugTest.kt
@@ -1,0 +1,85 @@
+package pl.allegro.tech.servicemesh.envoycontrol
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
+
+open class SnapshotDebugTest : EnvoyControlTestConfiguration() {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setupTest() {
+            setup()
+        }
+    }
+
+    @Test
+    open fun `getting snapshot debug info contains all information`() {
+        // given
+        registerService(name = "echo")
+        val nodeMetadata = envoyContainer1.admin().nodeInfo()
+
+        untilAsserted {
+            // when
+            val snapshot = envoyControl1.getSnapshot(nodeMetadata)
+
+            // then
+            Assertions.assertThat(snapshot).isNotEmpty()
+            Assertions.assertThat(snapshot)
+                .contains("clusters: ")
+                .contains("endpoints: ")
+                .contains("routes: ")
+                .contains("listeners: ")
+            Assertions.assertThat(snapshot)
+                .contains("clusters=SnapshotResources")
+                .contains("endpoints=SnapshotResources")
+                .contains("routes=SnapshotResources")
+                .contains("listeners=SnapshotResources")
+        }
+    }
+
+    val missingNodeJson = """{
+     "metadata": {
+      "service_name": "service-mesh-service-first",
+      "identity": "",
+      "service_version": "0.1.16-SKYHELIX-839-eds-version-metric-SNAPSHOT",
+      "proxy_settings": {
+       "incoming": {
+        "endpoints": null,
+        "healthCheck": null,
+        "roles": null,
+        "timeoutPolicy": null
+       },
+       "outgoing": {
+        "dependencies": [
+         {
+          "handleInternalRedirect": null,
+          "timeoutPolicy": null,
+          "endpoints": [],
+          "domain": null,
+          "service": "*"
+         }
+        ]
+       }
+      },
+      "ads": true
+     },
+     "locality": {
+      "zone": "dev-dc4"
+     },
+     "build_version": "b7bef67c256090919a4585a1a06c42f15d640a09/1.13.0-dev/Clean/RELEASE/BoringSSL"
+    }
+""".trim()
+
+    @Test
+    open fun `getting missing snapshot results returns valid description`() {
+        // when
+        val snapshot = envoyControl1.getSnapshot(missingNodeJson)
+
+        // then
+        Assertions.assertThat(snapshot).isNotEmpty()
+        Assertions.assertThat(snapshot).contains("snapshot missing")
+    }
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.pszymczyk.consul.infrastructure.Ports
+import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import org.springframework.boot.actuate.health.Status
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -22,6 +24,7 @@ interface EnvoyControlTestApp {
     fun stop()
     fun isHealthy(): Boolean
     fun getState(): ServicesState
+    fun getSnapshot(nodeJson: String): String
     fun getHealthStatus(): Health
     fun <T> bean(clazz: Class<T>): T
 }
@@ -78,6 +81,17 @@ class EnvoyControlRunnerTestApp(
             )
             .execute()
         return objectMapper.readValue(response.body()?.use { it.string() }, ServicesState::class.java)
+    }
+
+    override fun getSnapshot(nodeJson: String): String {
+        val response = httpClient.newCall(
+            Request.Builder()
+                .post(RequestBody.create(MediaType.get("application/json"), nodeJson))
+                .url("http://localhost:$appPort/snapshot")
+                .build()
+        ).execute()
+
+        return response.body().use {  it!!.string() }
     }
 
     private fun getApplicationStatusResponse(): Response =

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
@@ -91,7 +91,7 @@ class EnvoyControlRunnerTestApp(
                 .build()
         ).execute()
 
-        return response.body().use {  it!!.string() }
+        return response.body().use { it!!.string() }
     }
 
     private fun getApplicationStatusResponse(): Response =

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyAdmin.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyAdmin.kt
@@ -62,6 +62,17 @@ class EnvoyAdmin(
         }
     }
 
+    private fun configDump(): String {
+        val response = get("config_dump")
+        return response.body().use { it!!.string() }
+    }
+
+    fun nodeInfo(): String {
+        val configDump = configDump()
+        val node = objectMapper.readTree(configDump).at("/configs/0/bootstrap/node")
+        return objectMapper.writeValueAsString(node)
+    }
+
     fun circuitBreakerSetting(
         cluster: String,
         setting: String,


### PR DESCRIPTION
The debugging endpoint uses a textual representation. It's simple enough for a human to parse when debugging issues with a particular Envoy to compare what the control plane knows about it's configuration served via XDS. AutoValues make it difficult to map to JSON so I didn't want to over-engineer it.