### PR TITLE
debugging: /snapshot endpoint enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,8 @@ allprojects {
             cglib             : '3.2.9',
             logback           : '1.2.3',
             slf4j             : '1.7.25',
-            re2j              : '1.3'
+            re2j              : '1.3',
+            xxhash            : '0.10.1'
     ]
 }
 

--- a/envoy-control-runner/build.gradle
+++ b/envoy-control-runner/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: versions.kotlin
     compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: versions.jackson
+    compile group: 'net.openhft', name: 'zero-allocation-hashing', version: versions.xxhash
 }
 
 publishing {
@@ -32,5 +33,9 @@ publishing {
 test {
     maxParallelForks = 1
     useJUnitPlatform()
+}
+
+run {
+    systemProperties.putIfAbsent("spring.profiles.active", "local")
 }
 

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
@@ -36,20 +36,7 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
             throw ResponseStatusException(HttpStatus.NOT_FOUND, "snapshot missing")
         } else {
             ResponseEntity(
-                SnapshotDebugInfo(
-                    snapshot = Snapshot(
-                        clusters = snapshot.clusters().resources(),
-                        endpoints = snapshot.endpoints().resources(),
-                        listeners = snapshot.listeners().resources(),
-                        routes = snapshot.routes().resources()
-                    ),
-                    versions = Versions(
-                        clusters = version(snapshot.clusters().version()),
-                        endpoints = version(snapshot.endpoints().version()),
-                        listeners = version(snapshot.listeners().version()),
-                        routes = version(snapshot.routes().version())
-                    )
-                ),
+                SnapshotDebugInfo(snapshot),
                 HttpStatus.OK
             )
         }

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugController.kt
@@ -1,14 +1,20 @@
 package pl.allegro.tech.servicemesh.envoycontrol.snapshot.debug
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.google.protobuf.Message
+import com.google.protobuf.util.JsonFormat
 import io.envoyproxy.controlplane.cache.NodeGroup
-import io.envoyproxy.controlplane.cache.Snapshot
 import io.envoyproxy.controlplane.cache.SnapshotCache
 import io.envoyproxy.envoy.api.v2.core.Node
+import org.springframework.boot.jackson.JsonComponent
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import pl.allegro.tech.servicemesh.envoycontrol.ControlPlane
 import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
 
@@ -23,27 +29,36 @@ class SnapshotDebugController(controlPlane: ControlPlane) {
      * extracted from Envoy's config_dump endpoint.
      */
     @PostMapping("/snapshot")
-    fun snapshot(@RequestBody node: Node): ResponseEntity<String> {
+    fun snapshot(@RequestBody node: Node): ResponseEntity<SnapshotDebugInfo> {
         val nodeHash = nodeGroup.hash(node)
         val snapshot = cache.getSnapshot(nodeHash)
         return if (snapshot == null) {
-            return ResponseEntity("snapshot missing", HttpStatus.NOT_FOUND)
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "snapshot missing")
         } else {
             ResponseEntity(
-                versions(snapshot) +
-                    "snapshot:\n" +
-                    snapshot.toString(),
+                SnapshotDebugInfo(
+                    snapshot = Snapshot(
+                        clusters = snapshot.clusters().resources(),
+                        endpoints = snapshot.endpoints().resources(),
+                        listeners = snapshot.listeners().resources(),
+                        routes = snapshot.routes().resources()
+                    ),
+                    versions = Versions(
+                        clusters = version(snapshot.clusters().version()),
+                        endpoints = version(snapshot.endpoints().version()),
+                        listeners = version(snapshot.listeners().version()),
+                        routes = version(snapshot.routes().version())
+                    )
+                ),
                 HttpStatus.OK
             )
         }
     }
 
-    private fun versions(snapshot: Snapshot): String {
-        val versions = StringBuilder()
-            .append("clusters: ${snapshot.clusters().version()}\n")
-            .append("endpoints: ${snapshot.endpoints().version()}\n")
-            .append("routes: ${snapshot.routes().version()}\n")
-            .append("listeners: ${snapshot.listeners().version()}\n")
-        return versions.toString()
+    @JsonComponent
+    class ProtoSerializer : JsonSerializer<Message>() {
+        override fun serialize(message: Message, gen: JsonGenerator, serializers: SerializerProvider) {
+            gen.writeRawValue(JsonFormat.printer().print(message))
+        }
     }
 }

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugInfo.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugInfo.kt
@@ -1,0 +1,37 @@
+package pl.allegro.tech.servicemesh.envoycontrol.snapshot.debug
+
+import io.envoyproxy.envoy.api.v2.Cluster
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment
+import io.envoyproxy.envoy.api.v2.Listener
+import io.envoyproxy.envoy.api.v2.RouteConfiguration
+import net.openhft.hashing.LongHashFunction
+
+fun version(version: String) = Version(
+    version,
+    // we use the same method of hashing as Envoy to create comparable string
+    java.lang.Long.toUnsignedString(LongHashFunction.xx().hashBytes(version.toByteArray(Charsets.US_ASCII)))
+)
+
+data class Version(
+    val raw: String,
+    val metric: String
+)
+
+data class Versions(
+    val clusters: Version,
+    val endpoints: Version,
+    val routes: Version,
+    val listeners: Version
+)
+
+data class Snapshot(
+    val clusters: Map<String, Cluster>,
+    val endpoints: Map<String, ClusterLoadAssignment>,
+    val listeners: Map<String, Listener>,
+    val routes: Map<String, RouteConfiguration>
+)
+
+data class SnapshotDebugInfo(
+    val snapshot: Snapshot,
+    val versions: Versions
+)

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugInfo.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/debug/SnapshotDebugInfo.kt
@@ -34,4 +34,19 @@ data class Snapshot(
 data class SnapshotDebugInfo(
     val snapshot: Snapshot,
     val versions: Versions
-)
+) {
+    constructor(snapshot: io.envoyproxy.controlplane.cache.Snapshot) : this(
+        snapshot = Snapshot(
+            clusters = snapshot.clusters().resources(),
+            endpoints = snapshot.endpoints().resources(),
+            listeners = snapshot.listeners().resources(),
+            routes = snapshot.routes().resources()
+        ),
+        versions = Versions(
+            clusters = version(snapshot.clusters().version()),
+            endpoints = version(snapshot.endpoints().version()),
+            listeners = version(snapshot.listeners().version()),
+            routes = version(snapshot.routes().version())
+        )
+    )
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
@@ -98,7 +98,12 @@ class EnvoyControlRunnerTestApp(
         }
 
         return response.body()
-            .use { objectMapper.readValue(it!!.byteStream(), SnapshotDebugResponse::class.java) }
+            ?.use { objectMapper.readValue(it.byteStream(), SnapshotDebugResponse::class.java) }
+            ?.copy(found = true) ?: throw SnapshotDebugResponseMissingException()
+    }
+
+    class SnapshotDebugResponseMissingException :
+        RuntimeException("Expected snapshot debug in response body but got none")
             .copy(found = true)
     }
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
@@ -104,8 +104,6 @@ class EnvoyControlRunnerTestApp(
 
     class SnapshotDebugResponseMissingException :
         RuntimeException("Expected snapshot debug in response body but got none")
-            .copy(found = true)
-    }
 
     private fun getApplicationStatusResponse(): Response =
         httpClient

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestApp.kt
@@ -2,6 +2,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.config
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.pszymczyk.consul.infrastructure.Ports
 import okhttp3.MediaType
@@ -14,6 +15,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder
 import pl.allegro.tech.servicemesh.envoycontrol.EnvoyControl
 import pl.allegro.tech.servicemesh.envoycontrol.logger
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServicesState
+import pl.allegro.tech.servicemesh.envoycontrol.snapshot.debug.Versions
 import java.time.Duration
 
 interface EnvoyControlTestApp {
@@ -24,7 +26,7 @@ interface EnvoyControlTestApp {
     fun stop()
     fun isHealthy(): Boolean
     fun getState(): ServicesState
-    fun getSnapshot(nodeJson: String): String
+    fun getSnapshot(nodeJson: String): SnapshotDebugResponse
     fun getHealthStatus(): Health
     fun <T> bean(clazz: Class<T>): T
 }
@@ -83,7 +85,7 @@ class EnvoyControlRunnerTestApp(
         return objectMapper.readValue(response.body()?.use { it.string() }, ServicesState::class.java)
     }
 
-    override fun getSnapshot(nodeJson: String): String {
+    override fun getSnapshot(nodeJson: String): SnapshotDebugResponse {
         val response = httpClient.newCall(
             Request.Builder()
                 .post(RequestBody.create(MediaType.get("application/json"), nodeJson))
@@ -91,7 +93,13 @@ class EnvoyControlRunnerTestApp(
                 .build()
         ).execute()
 
-        return response.body().use { it!!.string() }
+        if (!response.isSuccessful) {
+            return SnapshotDebugResponse(found = false)
+        }
+
+        return response.body()
+            .use { objectMapper.readValue(it!!.byteStream(), SnapshotDebugResponse::class.java) }
+            .copy(found = true)
     }
 
     private fun getApplicationStatusResponse(): Response =
@@ -121,4 +129,10 @@ data class Health(
 
 data class HealthDetails(
     val status: Status
+)
+
+data class SnapshotDebugResponse(
+    val found: Boolean,
+    val versions: Versions? = null,
+    val snapshot: ObjectNode? = null
 )


### PR DESCRIPTION
* show xDS versions in the same format as in Envoy metrics (/stats)
* json output

example response:
```json
{
 "versions": {
  "clusters": {
   "raw": "f57c5fd274a946e8b31697b420a83895",
   "metric": "8397944043068236980"
  },
  "listeners": {
   "raw": "empty",
   "metric": "11940367550976402267"
  },
  "routes": {
   "raw": "f57c5fd274a946e8b31697b420a83895",
   "metric": "8397944043068236980"
  },
  "endpoints": {
   "raw": "e379fcc12d94474dbc24210a4bc94857",
   "metric": "8333465023560272944"
  }
 },
 "snapshot": {
  "clusters": {
      // snapshot content
  }
// snapshot content
}
```