### PR TITLE
Increase number of retries when publishing release artifact to nexus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ subprojects {
             jvmTarget = '1.8'
         }
     }
-    
+
     dependencies {
         testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
         testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
@@ -172,6 +172,6 @@ subprojects {
 nexusStaging {
     packageGroup = "pl.allegro"
 
-    numberOfRetries = 15
+    numberOfRetries = 50
     delayBetweenRetriesInMillis = 5000
 }


### PR DESCRIPTION
It should fix the problem:
> repository x (in 'open' state) is in transition. Check again later.'. Giving up. Configure longer timeout if necessary.

1 retry takes approximately 7.4 second
So we increase timeout from ~2 minutes to ~6 minutes