### PR TITLE
log combineLatest suppressed error

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
@@ -3,6 +3,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.synchronization
 import io.micrometer.core.instrument.MeterRegistry
 import pl.allegro.tech.servicemesh.envoycontrol.services.LocalityAwareServicesState
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceChanges
+import pl.allegro.tech.servicemesh.envoycontrol.utils.logSuppressedError
 import pl.allegro.tech.servicemesh.envoycontrol.utils.measureBuffer
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
@@ -28,6 +29,7 @@ class GlobalServiceChanges(
                 .flatten()
                 .toList()
         }
+            .logSuppressedError("combineLatest() suppressed exception")
             .measureBuffer("global-service-changes-combine-latest", meterRegistry)
             .checkpoint("global-service-changes-emitted")
             .name("global-service-changes-emitted").metrics()

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/utils/ReactorUtils.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/utils/ReactorUtils.kt
@@ -1,13 +1,21 @@
 package pl.allegro.tech.servicemesh.envoycontrol.utils
 
 import io.micrometer.core.instrument.MeterRegistry
+import org.reactivestreams.Subscription
 import org.slf4j.LoggerFactory
+import reactor.core.Disposable
 import reactor.core.Fuseable
 import reactor.core.Scannable
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import kotlin.streams.asSequence
 
 private val logger = LoggerFactory.getLogger("pl.allegro.tech.servicemesh.envoycontrol.utils.ReactorUtils")
+private val scheduler by lazy { Schedulers.newSingle("reactor-utils-scheduler") }
+private const val DEFAULT_CHECK_INTERVAL_SECONDS = 60L
+private val defaultCheckInterval = Duration.ofSeconds(DEFAULT_CHECK_INTERVAL_SECONDS)
 
 /**
  * Measures buffer size of compatible reactor operators. Reports it as a metric.
@@ -46,6 +54,43 @@ fun <T> Flux<T>.onBackpressureLatestMeasured(name: String, meterRegistry: MeterR
     measureDiscardedItems("$name-before", meterRegistry)
         .onBackpressureLatest()
         .measureDiscardedItems(name, meterRegistry)
+
+/**
+ * It is possible that operator combineLatest() or maybe other operators may send cancel() to upstream publisher but
+ * don't send error to a subscriber. The error is stored internally but is not dispatched due to some kind of deadlock.
+ * This method can be used to log such a exception despite that.
+ */
+fun <T> Flux<T>.logSuppressedError(message: String, checkInterval: Duration = defaultCheckInterval): Flux<T> {
+    var subscribtion: Subscription? = null
+    var task: Disposable? = null
+    return this
+        .doOnSubscribe { s ->
+            subscribtion = s
+            task?.dispose()
+            task = scheduler.schedulePeriodically(
+                {
+                    if (logError(s, message)) {
+                        task?.dispose()
+                    }
+                },
+                checkInterval.toMillis(),
+                checkInterval.toMillis(),
+                TimeUnit.MILLISECONDS
+            )
+        }
+        .doFinally {
+            task?.dispose()
+            subscribtion?.let { logError(it, message) }
+        }
+}
+
+private fun logError(s: Subscription, message: String): Boolean = Scannable.from(s)
+    .scan(Scannable.Attr.ERROR)
+    ?.let {
+        logger.error(message, it)
+        true
+    }
+    ?: false
 
 /**
  * Flux.combineLatest() is an example of QueueSubscription


### PR DESCRIPTION
Add helper method for Flux to periodically check and log suppressed error on subscriber.
We know that operator combineLatest sometimes fails, sends cancel() to upstream but doesn't propagate error, so we don't see what happended. This change should make the error visible.