### PR TITLE
GlobalServiceChanges - experimental combineLatest flow fix

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
@@ -5,17 +5,23 @@ import pl.allegro.tech.servicemesh.envoycontrol.services.LocalityAwareServicesSt
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceChanges
 import pl.allegro.tech.servicemesh.envoycontrol.utils.logSuppressedError
 import pl.allegro.tech.servicemesh.envoycontrol.utils.measureBuffer
+import pl.allegro.tech.servicemesh.envoycontrol.utils.onBackpressureLatestMeasured
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
 
 class GlobalServiceChanges(
     private val serviceChanges: Array<ServiceChanges>,
-    private val meterRegistry: MeterRegistry
+    private val meterRegistry: MeterRegistry,
+    private val properties: SyncProperties
 ) {
     private val scheduler = Schedulers.newElastic("global-service-changes-combinator")
 
     fun combined(): Flux<List<LocalityAwareServicesState>> {
         val serviceStatesStreams: List<Flux<Set<LocalityAwareServicesState>>> = serviceChanges.map { it.stream() }
+
+        if (properties.combineServiceChangesExperimentalFlow) {
+            return combinedExperimentalFlow(serviceStatesStreams)
+        }
 
         return Flux.combineLatest(
             serviceStatesStreams.map {
@@ -33,5 +39,34 @@ class GlobalServiceChanges(
             .measureBuffer("global-service-changes-combine-latest", meterRegistry)
             .checkpoint("global-service-changes-emitted")
             .name("global-service-changes-emitted").metrics()
+    }
+
+    private fun combinedExperimentalFlow(
+        serviceStatesStreams: List<Flux<Set<LocalityAwareServicesState>>>
+    ): Flux<List<LocalityAwareServicesState>> {
+
+        return Flux.combineLatest(
+            serviceStatesStreams.map {
+                // if a number of items emitted by one source is very high, combineLatest may entirely ignore items
+                // emitted by other sources. publishOn with multithreaded scheduler prevents it.
+                //
+                // onBackpressureLatest ensures that combineLatest sources respect backpressure, so combineLatest
+                // will not fail with "Queue is full: Reactive Streams source doesn't respect backpressure" suppressed
+                // error
+                it.publishOn(scheduler, 1).onBackpressureLatest()
+            }
+        ) { statesArray ->
+            (statesArray.asSequence() as Sequence<List<LocalityAwareServicesState>>)
+                .flatten()
+                .toList()
+        }
+            .logSuppressedError("combineLatest() suppressed exception")
+            .measureBuffer("global-service-changes-combine-latest", meterRegistry)
+            .checkpoint("global-service-changes-emitted")
+            .name("global-service-changes-emitted").metrics()
+            .onBackpressureLatestMeasured("global-service-changes-backpressure", meterRegistry)
+            .publishOn(scheduler, 1)
+            .checkpoint("global-service-changes-published")
+            .name("global-service-changes-published").metrics()
     }
 }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/SyncProperties.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/SyncProperties.kt
@@ -10,4 +10,5 @@ class SyncProperties {
     var connectionTimeout: Duration = Duration.ofMillis(1000)
     var readTimeout: Duration = Duration.ofMillis(500)
     var envoyControlAppName = "envoy-control"
+    var combineServiceChangesExperimentalFlow = false
 }

--- a/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/infrastructure/ControlPlaneConfig.kt
+++ b/envoy-control-runner/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/infrastructure/ControlPlaneConfig.kt
@@ -122,9 +122,10 @@ class ControlPlaneConfig {
     @Bean
     fun globalServiceChanges(
         serviceChanges: Array<ServiceChanges>,
-        meterRegistry: MeterRegistry
+        meterRegistry: MeterRegistry,
+        properties: EnvoyControlProperties
     ): GlobalServiceChanges =
-        GlobalServiceChanges(serviceChanges, meterRegistry)
+        GlobalServiceChanges(serviceChanges, meterRegistry, properties.sync)
 
     @Bean
     fun envoyHttpFilters(


### PR DESCRIPTION
Fix for combineLatest() flux operator, that sometimes fails silently and sends cancel to an upstream.
We detected that after the fail, the combineLatest operator has an Exception saved internally, but not propagated to a downstream. The exception is:
> reactor.core.Exceptions$OverflowException: Queue is full: Reactive Streams source doesn't respect backpressure

This is an experimental fix for this problem, which has to be yet verified to decide if it helps with the problem. Hence it is disabled by default and enabled by flag.