### PR TITLE
#110 List of LocalityAwareServicesState instead of Set

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdater.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdater.kt
@@ -35,6 +35,8 @@ class SnapshotUpdater(
     }
 
     private val versions = SnapshotsVersions()
+
+    // TODO(dj): #110 consider plugging the factories externally
     private val snapshotFactory = EnvoySnapshotFactory(
         ingressRoutesFactory = EnvoyIngressRoutesFactory(properties),
         egressRoutesFactory = EnvoyEgressRoutesFactory(properties),

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServiceChanges.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServiceChanges.kt
@@ -7,12 +7,12 @@ import reactor.core.publisher.Flux
 
 class CrossDcServiceChanges(
     val properties: EnvoyControlProperties,
-    val crossDcService: CrossDcServices
+    private val crossDcService: CrossDcServices
 ) : ServiceChanges {
-    override fun stream(): Flux<Set<LocalityAwareServicesState>> =
+    override fun stream(): Flux<List<LocalityAwareServicesState>> =
         crossDcService
             .getChanges(properties.sync.pollingInterval)
-            .startWith(emptySet<LocalityAwareServicesState>())
+            .startWith(emptyList<LocalityAwareServicesState>())
             .distinctUntilChanged()
             .name("cross-dc-changes-distinct").metrics()
 }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServices.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServices.kt
@@ -22,7 +22,7 @@ class CrossDcServices(
     private val logger by logger()
     private val dcServicesCache = ConcurrentHashMap<String, LocalityAwareServicesState>()
 
-    fun getChanges(interval: Long): Flux<Set<LocalityAwareServicesState>> {
+    fun getChanges(interval: Long): Flux<List<LocalityAwareServicesState>> {
         return Flux
             .interval(Duration.ofSeconds(0), Duration.ofSeconds(interval))
             .checkpoint("cross-dc-services-ticks")
@@ -38,7 +38,7 @@ class CrossDcServices(
                     .map { dc -> dcWithControlPlaneInstances(dc) }
                     .filter { (_, instances) -> instances.isNotEmpty() }
                     .flatMap { (dc, instances) -> servicesStateFromDc(dc, instances) }
-                    .collect(Collectors.toSet())
+                    .collect(Collectors.toList())
             }
             .measureBuffer("cross-dc-services-flat-map", meterRegistry)
             .filter {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/GlobalServiceChanges.kt
@@ -17,7 +17,8 @@ class GlobalServiceChanges(
     private val scheduler = Schedulers.newElastic("global-service-changes-combinator")
 
     fun combined(): Flux<List<LocalityAwareServicesState>> {
-        val serviceStatesStreams: List<Flux<Set<LocalityAwareServicesState>>> = serviceChanges.map { it.stream() }
+        // TODO(dj): #110 List<Flux<List<X>>> needs to look like domain oriented code
+        val serviceStatesStreams: List<Flux<List<LocalityAwareServicesState>>> = serviceChanges.map { it.stream() }
 
         if (properties.combineServiceChangesExperimentalFlow) {
             return combinedExperimentalFlow(serviceStatesStreams)
@@ -42,7 +43,7 @@ class GlobalServiceChanges(
     }
 
     private fun combinedExperimentalFlow(
-        serviceStatesStreams: List<Flux<Set<LocalityAwareServicesState>>>
+        serviceStatesStreams: List<Flux<List<LocalityAwareServicesState>>>
     ): Flux<List<LocalityAwareServicesState>> {
 
         return Flux.combineLatest(

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServicesTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/CrossDcServicesTest.kt
@@ -21,7 +21,7 @@ class CrossDcServicesTest {
         val result = service
             .getChanges(1)
             .blockFirst()
-            ?: emptySet()
+            ?: emptyList()
 
         assertThat(result).hasSize(2)
         assertThat(result.map { it.zone }.toSet()).isEqualTo(setOf("dc1", "dc2"))
@@ -34,7 +34,7 @@ class CrossDcServicesTest {
         val result = service
             .getChanges(1)
             .blockFirst()
-            ?: emptySet()
+            ?: emptyList()
 
         assertThat(result).hasSize(1)
         assertThat(result.map { it.zone }).contains("dc1")
@@ -52,7 +52,7 @@ class CrossDcServicesTest {
         val result = service
             .getChanges(1)
             .blockFirst()
-            ?: emptySet()
+            ?: emptyList()
 
         assertThat(result).isNotEmpty
         assertThat(result.flatMap { it.servicesState.serviceNames() }.toSet()).isEqualTo(setOf("dc1", "dc3"))
@@ -66,14 +66,14 @@ class CrossDcServicesTest {
         val successfulResult = service
             .getChanges(1)
             .blockFirst()
-            ?: emptySet()
+            ?: emptyList()
 
         assertThat(successfulResult).containsExactlyInAnyOrder(*(expectedSuccessfulState.toTypedArray()))
 
         val oneInstanceFailing = service
             .getChanges(1)
             .blockFirst()
-            ?: emptySet()
+            ?: emptyList()
 
         assertThat(oneInstanceFailing).containsExactlyInAnyOrder(*(expectedStateWithOneRequestFailing.toTypedArray()))
     }

--- a/envoy-control-services/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/ServiceChanges.kt
+++ b/envoy-control-services/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/ServiceChanges.kt
@@ -3,5 +3,5 @@ package pl.allegro.tech.servicemesh.envoycontrol.services
 import reactor.core.publisher.Flux
 
 interface ServiceChanges {
-    fun stream(): Flux<Set<LocalityAwareServicesState>>
+    fun stream(): Flux<List<LocalityAwareServicesState>>
 }

--- a/envoy-control-source-consul/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/consul/services/ConsulLocalServiceChanges.kt
+++ b/envoy-control-source-consul/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/consul/services/ConsulLocalServiceChanges.kt
@@ -15,7 +15,7 @@ class ConsulLocalServiceChanges(
     private val transformers: List<ServiceInstancesTransformer> = emptyList(),
     override val latestServiceState: AtomicReference<ServicesState> = AtomicReference(ServicesState())
 ) : LocalServiceChanges {
-    override fun stream(): Flux<Set<LocalityAwareServicesState>> =
+    override fun stream(): Flux<List<LocalityAwareServicesState>> =
         consulChanges
             .watchState()
             .map { state ->
@@ -28,7 +28,7 @@ class ConsulLocalServiceChanges(
             }
             .doOnNext { latestServiceState.set(it) }
             .map {
-                setOf(LocalityAwareServicesState(it, locality, localDc))
+                listOf(LocalityAwareServicesState(it, locality, localDc))
             }
 
     override fun isServiceStateLoaded(): Boolean = latestServiceState.get() != ServicesState()


### PR DESCRIPTION
This is the first step of refactoring. The next ones will transform sets and lists of `LocalityAwareServicesState` into a more cohesive and comprehensible suite of names.