### PR TITLE
Fix MultiClusterState

### DIFF
--- a/envoy-control-services/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/ClusterState.kt
+++ b/envoy-control-services/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/ClusterState.kt
@@ -10,7 +10,7 @@ data class ClusterState(
     val zone: String
 )
 
-class MultiClusterState(l: List<ClusterState> = listOf()) : Collection<ClusterState> by l {
+data class MultiClusterState(private val l: List<ClusterState> = listOf()) : Collection<ClusterState> by l {
 
     constructor(state: ClusterState) : this(listOf(state))
 

--- a/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
+++ b/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
@@ -8,11 +8,14 @@ internal class MultiClusterStateTest {
     @Test
     fun `MultiCLusterStates should implement equality`() {
         // given
-        val element = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
-        val serviceInstances = ServiceInstances("a", setOf(element))
-        val l = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances)), Locality.REMOTE, "dc1"))
-        val multiClusterState1 = MultiClusterState(l)
-        val multiClusterState2 = MultiClusterState(l)
+        val serviceInstance1 = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
+        val serviceInstance2 = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
+        val serviceInstances1 = ServiceInstances("a", setOf(serviceInstance1))
+        val serviceInstances2 = ServiceInstances("a", setOf(serviceInstance2))
+        val state1 = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances1)), Locality.REMOTE, "dc1"))
+        val state2 = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances2)), Locality.REMOTE, "dc1"))
+        val multiClusterState1 = MultiClusterState(state1)
+        val multiClusterState2 = MultiClusterState(state2)
 
         // then
         assertThat(multiClusterState1).isEqualTo(multiClusterState2)

--- a/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
+++ b/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
@@ -1,0 +1,20 @@
+package pl.allegro.tech.servicemesh.envoycontrol.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class MultiClusterStateTest {
+
+    @Test
+    fun `MultiCLusterStates should implement equality`() {
+        // given
+        val element = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
+        val serviceInstances = ServiceInstances("a", setOf(element))
+        val l = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances)), Locality.REMOTE, "dc1"))
+        val multiClusterState1 = MultiClusterState(l)
+        val multiClusterState2 = MultiClusterState(l)
+
+        // then
+        assertThat(multiClusterState1).isEqualTo(multiClusterState2)
+    }
+}

--- a/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
+++ b/envoy-control-services/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/services/MultiClusterStateTest.kt
@@ -8,16 +8,17 @@ internal class MultiClusterStateTest {
     @Test
     fun `MultiCLusterStates should implement equality`() {
         // given
-        val serviceInstance1 = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
-        val serviceInstance2 = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
-        val serviceInstances1 = ServiceInstances("a", setOf(serviceInstance1))
-        val serviceInstances2 = ServiceInstances("a", setOf(serviceInstance2))
-        val state1 = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances1)), Locality.REMOTE, "dc1"))
-        val state2 = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances2)), Locality.REMOTE, "dc1"))
-        val multiClusterState1 = MultiClusterState(state1)
-        val multiClusterState2 = MultiClusterState(state2)
+        val multiClusterState1 = createMultiClusterState()
+        val multiClusterState2 = createMultiClusterState()
 
         // then
         assertThat(multiClusterState1).isEqualTo(multiClusterState2)
+    }
+
+    private fun createMultiClusterState(): MultiClusterState {
+        val serviceInstance = ServiceInstance("1", address = "0.0.0.0", port = 1, tags = setOf("a"))
+        val serviceInstances = ServiceInstances("a", setOf(serviceInstance))
+        val state = listOf(ClusterState(ServicesState(mapOf("a" to serviceInstances)), Locality.REMOTE, "dc1"))
+        return MultiClusterState(state)
     }
 }


### PR DESCRIPTION
When `MultiClusterState` does not implement equals then every change from remote DC is treated as a different one, even if it's not. This fixes this problem.