### PR TITLE
Migrates more tests to the new approach

### DIFF
--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/InternalRedirectTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/InternalRedirectTest.kt
@@ -1,64 +1,94 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlRunnerTestApp
-import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.redirect.RedirectServiceContainer
 import java.net.UnknownHostException
 
-open class InternalRedirectTest : EnvoyControlTestConfiguration() {
+class InternalRedirectTest {
 
     companion object {
-        private val redirectServiceContainer = RedirectServiceContainer(redirectTo = "service-1")
-        private val properties = mapOf(
+
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(consul, mapOf(
             "envoy-control.envoy.snapshot.egress.handleInternalRedirect" to false
-        )
+        ))
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl, service)
+
+        val redirectServiceContainer = RedirectServiceContainer(redirectTo = "service-1")
 
         @JvmStatic
         @BeforeAll
         fun setupTest() {
-            setup(appFactoryForEc1 = { consulPort ->
-                EnvoyControlRunnerTestApp(properties = properties, consulPort = consulPort)
-            })
             redirectServiceContainer.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardownTest() {
+            redirectServiceContainer.stop()
         }
     }
 
     @Test
     fun `redirect should be handled by envoy and response from service-1 is returned`() {
         // given
-        registerService(name = "service-1")
+        consul.server.operations.registerService(service, name = "service-1")
         // service-redirect has defined in metadata redirect policy
-        registerRedirectService(serviceName = "service-redirect")
+        registerRedirectService(name = "service-redirect")
 
         untilAsserted {
             // when
-            val response = callService(service = "service-redirect")
+            val response = envoy.egressOperations.callService("service-redirect")
 
             // then
-            assertThat(response).isOk().isFrom(echoContainer)
+            assertThat(response).isOk().isFrom(service)
         }
     }
 
     @Test
     fun `envoy should not handle redirects by default`() {
         // given
-        registerService(name = "service-1")
-        registerRedirectService(serviceName = "service-5")
+        consul.server.operations.registerService(service, name = "service-1")
+        registerRedirectService(name = "service-5")
 
         untilAsserted {
             // when
-            val exception = assertThrows<UnknownHostException> { callService(service = "service-5") }
+            val exception = assertThrows<UnknownHostException> {
+                envoy.egressOperations.callService("service-5")
+            }
 
             // then
             assertThat(exception.message).contains("service-1")
         }
     }
 
-    private fun registerRedirectService(serviceName: String) {
-        registerService(name = serviceName, container = redirectServiceContainer, port = RedirectServiceContainer.PORT)
+    fun registerRedirectService(name: String) {
+        consul.server.operations.registerService(
+            name = name, address = redirectServiceContainer.ipAddress(), port = RedirectServiceContainer.PORT
+        )
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceCustomHealthCheckRouteTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceCustomHealthCheckRouteTest.kt
@@ -2,41 +2,51 @@ package pl.allegro.tech.servicemesh.envoycontrol
 
 import okhttp3.Headers
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
 import pl.allegro.tech.servicemesh.envoycontrol.config.AdsCustomHealthCheck
-import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlRunnerTestApp
-import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 
-internal class LocalServiceCustomHealthCheckRouteTest : EnvoyControlTestConfiguration() {
+class LocalServiceCustomHealthCheckRouteTest {
 
     companion object {
 
-        @JvmStatic
-        @BeforeAll
-        fun setupTest() {
-            setup(
-                envoyConfig = AdsCustomHealthCheck,
-                appFactoryForEc1 = { consulPort -> EnvoyControlRunnerTestApp(emptyMap(), consulPort) }
-            )
-        }
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(consul)
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl, service, AdsCustomHealthCheck)
     }
 
     @Test
     fun `should health check be routed to custom cluster`() {
         untilAsserted {
             // when
-            callLocalService(endpoint = "/status/custom", headers = Headers.of())
+            envoy.ingressOperations.callLocalService(endpoint = "/status/custom", headers = Headers.of())
 
             // then
-            assertThat(envoyContainer1.admin().statValue("cluster.local_service_health_check.upstream_rq_200")?.toInt()).isGreaterThan(0)
-            assertThat(envoyContainer1.admin().statValue("cluster.local_service.upstream_rq_200")?.toInt()).isEqualTo(-1)
+            assertThat(envoy.container.admin().statValue("cluster.local_service_health_check.upstream_rq_200")?.toInt()).isGreaterThan(0)
+            assertThat(envoy.container.admin().statValue("cluster.local_service.upstream_rq_200")?.toInt()).isEqualTo(-1)
         }
 
         // and
-        callLocalService(endpoint = "/status/ping", headers = Headers.of())
+        envoy.ingressOperations.callLocalService(endpoint = "/status/ping", headers = Headers.of())
 
         // then
-        assertThat(envoyContainer1.admin().statValue("cluster.local_service.upstream_rq_200")?.toInt()).isEqualTo(1)
+        assertThat(envoy.container.admin().statValue("cluster.local_service.upstream_rq_200")?.toInt()).isEqualTo(1)
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OriginalDestinationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OriginalDestinationTest.kt
@@ -1,32 +1,45 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 
-internal class OriginalDestinationTest : EnvoyControlTestConfiguration() {
+class OriginalDestinationTest {
 
     companion object {
 
-        @JvmStatic
-        @BeforeAll
-        fun setupTest() {
-            setup()
-        }
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(consul)
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl)
     }
 
     @Test
     fun `should send direct request when host envoy-original-destination and header x-envoy-original-dst-host with IP provided`() {
         untilAsserted {
             // when
-            val response = callServiceWithOriginalDst(
-                echoContainer.address(),
-                envoyContainer1.egressListenerUrl()
-            )
+            val response = envoy.egressOperations.callServiceWithOriginalDst(service)
 
             // then
-            assertThat(response).isOk().isFrom(echoContainer)
+            assertThat(response).isOk().isFrom(service)
         }
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
@@ -85,8 +85,8 @@ interface OutgoingPermissionsTest {
     @Test
     fun `should only allow access to resources from node_metadata_dependencies`() {
         // given
-        consul().server.consulOperations.registerService(service().container, name = "not-accessible")
-        consul().server.consulOperations.registerService(service().container, name = "echo")
+        consul().server.operations.registerService(service().container, name = "not-accessible")
+        consul().server.operations.registerService(service().container, name = "echo")
 
         untilAsserted {
             // when

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
@@ -1,63 +1,103 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isUnreachable
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
 import pl.allegro.tech.servicemesh.envoycontrol.config.Ads
-import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlRunnerTestApp
-import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyControlTestConfiguration
 import pl.allegro.tech.servicemesh.envoycontrol.config.Xds
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 
-class AdsOutgoingPermissionsTest : OutgoingPermissionsTest() {
+class AdsOutgoingPermissionsTest : OutgoingPermissionsTest {
+
     companion object {
 
-        private val properties = mapOf("envoy-control.envoy.snapshot.outgoing-permissions.enabled" to true)
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
 
-        @JvmStatic
-        @BeforeAll
-        fun setupTest() {
-            setup(
-                envoyConfig = Ads,
-                appFactoryForEc1 = { consulPort -> EnvoyControlRunnerTestApp(properties, consulPort) }
-            )
-        }
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(consul, mapOf(
+            "envoy-control.envoy.snapshot.outgoing-permissions.enabled" to true
+        ))
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl, config = Ads)
     }
+
+    override fun consul() = consul
+
+    override fun service() = service
+
+    override fun envoy() = envoy
 }
 
-class XdsOutgoingPermissionsTest : OutgoingPermissionsTest() {
+class XdsOutgoingPermissionsTest : OutgoingPermissionsTest {
+
     companion object {
 
-        private val properties = mapOf("envoy-control.envoy.snapshot.outgoing-permissions.enabled" to true)
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
 
-        @JvmStatic
-        @BeforeAll
-        fun setupTest() {
-            setup(
-                envoyConfig = Xds,
-                appFactoryForEc1 = { consulPort -> EnvoyControlRunnerTestApp(properties, consulPort) }
-            )
-        }
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(consul, mapOf(
+            "envoy-control.envoy.snapshot.outgoing-permissions.enabled" to true
+        ))
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl, config = Xds)
     }
+
+    override fun consul() = consul
+
+    override fun service() = service
+
+    override fun envoy() = envoy
 }
 
-abstract class OutgoingPermissionsTest : EnvoyControlTestConfiguration() {
+interface OutgoingPermissionsTest {
+
+    fun consul(): ConsulExtension
+
+    fun service(): EchoServiceExtension
+
+    fun envoy(): EnvoyExtension
 
     @Test
     fun `should only allow access to resources from node_metadata_dependencies`() {
         // given
-        registerService(name = "not-accessible", container = echoContainer)
-        registerService(name = "echo")
+        consul().server.consulOperations.registerService(service().container, name = "not-accessible")
+        consul().server.consulOperations.registerService(service().container, name = "echo")
 
         untilAsserted {
             // when
-            val unreachableResponse = callService(service = "not-accessible")
-            val unregisteredResponse = callService(service = "unregistered")
-            val reachableResponse = callEcho()
-            val reachableDomainResponse = callDomain("www.example.com")
-            val unreachableDomainResponse = callDomain("www.another-example.com")
+            val unreachableResponse = envoy().egressOperations.callService("not-accessible")
+            val unregisteredResponse = envoy().egressOperations.callService("unregistered")
+            val reachableResponse = envoy().egressOperations.callService("echo")
+            val reachableDomainResponse = envoy().egressOperations.callDomain("www.example.com")
+            val unreachableDomainResponse = envoy().egressOperations.callDomain("www.another-example.com")
 
             // then
-            assertThat(reachableResponse).isOk().isFrom(echoContainer)
+            assertThat(reachableResponse).isOk().isFrom(service().container)
             assertThat(reachableDomainResponse).isOk()
             assertThat(unreachableDomainResponse).isUnreachable()
             assertThat(unreachableResponse).isUnreachable()

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutgoingPermissionsTest.kt
@@ -85,8 +85,8 @@ interface OutgoingPermissionsTest {
     @Test
     fun `should only allow access to resources from node_metadata_dependencies`() {
         // given
-        consul().server.operations.registerService(service().container, name = "not-accessible")
-        consul().server.operations.registerService(service().container, name = "echo")
+        consul().server.operations.registerService(service(), name = "not-accessible")
+        consul().server.operations.registerService(service(), name = "echo")
 
         untilAsserted {
             // when
@@ -97,7 +97,7 @@ interface OutgoingPermissionsTest {
             val unreachableDomainResponse = envoy().egressOperations.callDomain("www.another-example.com")
 
             // then
-            assertThat(reachableResponse).isOk().isFrom(service().container)
+            assertThat(reachableResponse).isOk().isFrom(service())
             assertThat(reachableDomainResponse).isOk()
             assertThat(unreachableDomainResponse).isUnreachable()
             assertThat(unreachableResponse).isUnreachable()

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
@@ -42,8 +42,8 @@ class OutlierDetectionTest {
     fun `should not send requests to instance when outlier check failed`() {
         // given
         val unhealthyIp = unhealthyService.container.ipAddress()
-        consul.server.consulOperations.registerService(healthyService.container, name = "echo")
-        consul.server.consulOperations.registerService(unhealthyService.container, name = "echo")
+        consul.server.operations.registerService(healthyService.container, name = "echo")
+        consul.server.operations.registerService(unhealthyService.container, name = "echo")
         unhealthyService.container.stop()
 
         untilAsserted {

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
@@ -42,8 +42,8 @@ class OutlierDetectionTest {
     fun `should not send requests to instance when outlier check failed`() {
         // given
         val unhealthyIp = unhealthyService.container.ipAddress()
-        consul.server.operations.registerService(healthyService.container, name = "echo")
-        consul.server.operations.registerService(unhealthyService.container, name = "echo")
+        consul.server.operations.registerService(healthyService, name = "echo")
+        consul.server.operations.registerService(unhealthyService, name = "echo")
         unhealthyService.container.stop()
 
         untilAsserted {
@@ -60,7 +60,7 @@ class OutlierDetectionTest {
             val response = envoy.egressOperations.callService("echo")
 
             // then
-            assertThat(response).isOk().isFrom(healthyService.container)
+            assertThat(response).isOk().isFrom(healthyService)
         }
     }
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ParallelSnapshotForGroupsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ParallelSnapshotForGroupsTest.kt
@@ -45,7 +45,7 @@ class ParallelSnapshotForGroupsTest {
     @Test
     fun `should update multiple envoy's configs in PARALLEL mode`() {
         // when
-        consul.server.consulOperations.registerService(service.container, name = "echo")
+        consul.server.operations.registerService(service.container, name = "echo")
 
         // then
         untilAsserted {

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ParallelSnapshotForGroupsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ParallelSnapshotForGroupsTest.kt
@@ -45,15 +45,15 @@ class ParallelSnapshotForGroupsTest {
     @Test
     fun `should update multiple envoy's configs in PARALLEL mode`() {
         // when
-        consul.server.operations.registerService(service.container, name = "echo")
+        consul.server.operations.registerService(service, name = "echo")
 
         // then
         untilAsserted {
             envoy.egressOperations.callService(service = "echo").also {
-                assertThat(it).isOk().isFrom(service.container)
+                assertThat(it).isOk().isFrom(service)
             }
             secondEnvoy.egressOperations.callService(service = "echo").also {
-                assertThat(it).isOk().isFrom(service.container)
+                assertThat(it).isOk().isFrom(service)
             }
         }
     }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RegexServicesFilterTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RegexServicesFilterTest.kt
@@ -38,9 +38,9 @@ class RegexServicesFilterTest {
     @Test
     fun `should not reach service whose name ends with number from 1 to 4`() {
         // given
-        consul.server.operations.registerService(service.container, name = "service-1")
-        consul.server.operations.registerService(service.container, name = "service-2")
-        consul.server.operations.registerService(service.container, name = "service-3")
+        consul.server.operations.registerService(service, name = "service-1")
+        consul.server.operations.registerService(service, name = "service-2")
+        consul.server.operations.registerService(service, name = "service-3")
 
         untilAsserted {
             // when
@@ -51,7 +51,7 @@ class RegexServicesFilterTest {
             // then
             assertThat(response1).isUnreachable()
             assertThat(response2).isUnreachable()
-            assertThat(response3).isOk().isFrom(service.container)
+            assertThat(response3).isOk().isFrom(service)
         }
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RegexServicesFilterTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RegexServicesFilterTest.kt
@@ -38,9 +38,9 @@ class RegexServicesFilterTest {
     @Test
     fun `should not reach service whose name ends with number from 1 to 4`() {
         // given
-        consul.server.consulOperations.registerService(service.container, name = "service-1")
-        consul.server.consulOperations.registerService(service.container, name = "service-2")
-        consul.server.consulOperations.registerService(service.container, name = "service-3")
+        consul.server.operations.registerService(service.container, name = "service-1")
+        consul.server.operations.registerService(service.container, name = "service-2")
+        consul.server.operations.registerService(service.container, name = "service-3")
 
         untilAsserted {
             // when

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
@@ -35,13 +35,13 @@ interface ServiceTagsAndCanaryTestBase {
     fun envoy(): EnvoyExtension
 
     fun registerServices() {
-        consul().server.consulOperations.registerService(
+        consul().server.operations.registerService(
                 name = "echo", address = loremRegularService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("lorem")
         )
-        consul().server.consulOperations.registerService(
+        consul().server.operations.registerService(
                 name = "echo", address = loremCanaryService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("lorem", "canary")
         )
-        consul().server.consulOperations.registerService(
+        consul().server.operations.registerService(
                 name = "echo", address = ipsumRegularService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("ipsum")
         )
     }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
@@ -7,7 +7,6 @@ import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
 import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
-import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
 import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.CallStats
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
@@ -35,15 +34,9 @@ interface ServiceTagsAndCanaryTestBase {
     fun envoy(): EnvoyExtension
 
     fun registerServices() {
-        consul().server.operations.registerService(
-                name = "echo", address = loremRegularService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("lorem")
-        )
-        consul().server.operations.registerService(
-                name = "echo", address = loremCanaryService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("lorem", "canary")
-        )
-        consul().server.operations.registerService(
-                name = "echo", address = ipsumRegularService.container.ipAddress(), port = EchoContainer.PORT, tags = listOf("ipsum")
-        )
+        consul().server.operations.registerService(loremRegularService, name = "echo", tags = listOf("lorem"))
+        consul().server.operations.registerService(loremCanaryService, name = "echo", tags = listOf("lorem", "canary"))
+        consul().server.operations.registerService(ipsumRegularService, name = "echo", tags = listOf("ipsum"))
     }
 
     @Test

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
@@ -2,8 +2,24 @@ package pl.allegro.tech.servicemesh.envoycontrol.assertions
 
 import okhttp3.Response
 import org.assertj.core.api.ObjectAssert
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
 
 fun ObjectAssert<Response>.isOk(): ObjectAssert<Response> {
     matches { it.isSuccessful }
+    return this
+}
+
+fun ObjectAssert<Response>.isUnreachable(): ObjectAssert<Response> {
+    matches({
+        it.body()?.close()
+        it.code() == 503 || it.code() == 504
+    }, "is unreachable")
+    return this
+}
+
+fun ObjectAssert<Response>.isFrom(echoContainer: EchoContainer): ObjectAssert<Response> {
+    matches {
+        it.body()?.use { it.string().contains(echoContainer.response) } ?: false
+    }
     return this
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
@@ -2,7 +2,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.assertions
 
 import okhttp3.Response
 import org.assertj.core.api.ObjectAssert
-import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
 
 fun ObjectAssert<Response>.isOk(): ObjectAssert<Response> {
     matches { it.isSuccessful }
@@ -17,9 +17,9 @@ fun ObjectAssert<Response>.isUnreachable(): ObjectAssert<Response> {
     return this
 }
 
-fun ObjectAssert<Response>.isFrom(echoContainer: EchoContainer): ObjectAssert<Response> {
+fun ObjectAssert<Response>.isFrom(echoServiceExtension: EchoServiceExtension): ObjectAssert<Response> {
     matches {
-        it.body()?.use { it.string().contains(echoContainer.response) } ?: false
+        it.body()?.use { it.string().contains(echoServiceExtension.container.response) } ?: false
     }
     return this
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/BaseEnvoyTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/BaseEnvoyTest.kt
@@ -40,8 +40,8 @@ open class BaseEnvoyTest {
         var consulAgentInDc1: ConsulSetup
         var lowRpcConsulClient: ConsulSetup
 
-        val consulOperationsInFirstDc = consulMastersInDc1[0].consulOperations
-        val consulOperationsInSecondDc = consulMastersInDc2[0].consulOperations
+        val consulOperationsInFirstDc = consulMastersInDc1[0].operations
+        val consulOperationsInSecondDc = consulMastersInDc2[0].operations
         val consulHttpPort = consulMastersInDc1[0].port
         val consul2HttpPort = consulMastersInDc2[0].port
         val consul: ConsulContainer = consulMastersInDc1[0].container
@@ -153,7 +153,7 @@ open class BaseEnvoyTest {
         fun deregisterAllServices() {
             consulOperationsInFirstDc.deregisterAll()
             consulOperationsInSecondDc.deregisterAll()
-            consulAgentInDc1.consulOperations.deregisterAll()
+            consulAgentInDc1.operations.deregisterAll()
             sleep(1000) // todo remove it?
         }
     }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/EnvoyControlTestConfiguration.kt
@@ -311,17 +311,6 @@ abstract class EnvoyControlTestConfiguration : BaseEnvoyTest() {
             return request.execute()
         }
 
-        fun callServiceWithOriginalDst(originalDstUrl: String, envoyUrl: String): Response =
-            defaultClient.newCall(
-                Request.Builder()
-                    .get()
-                    .header("Host", "envoy-original-destination")
-                    .header("x-envoy-original-dst-host", originalDstUrl)
-                    .url(envoyUrl)
-                    .build()
-            )
-                .execute()
-
         fun callLocalService(
             endpoint: String,
             headers: Headers,

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
@@ -24,7 +24,7 @@ class ConsulExtension : BeforeAllCallback, AfterAllCallback, AfterEachCallback {
     }
 
     override fun afterEach(context: ExtensionContext) {
-        server.consulOperations.deregisterAll()
+        server.operations.deregisterAll()
     }
 
     override fun afterAll(context: ExtensionContext) {

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -33,7 +33,7 @@ class ConsulOperations(port: Int) {
     }
 
     fun registerService(
-        extension: ServiceExtension,
+        extension: ServiceExtension<*>,
         id: String = UUID.randomUUID().toString(),
         name: String,
         registerDefaultCheck: Boolean = false,

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -12,9 +12,9 @@ class ConsulOperations(port: Int) {
 
     fun registerService(
         id: String = UUID.randomUUID().toString(),
-        name: String = "sample",
-        address: String = "localhost",
-        port: Int = 1234,
+        name: String,
+        address: String,
+        port: Int,
         registerDefaultCheck: Boolean = false,
         tags: List<String> = listOf("a")
     ): String {
@@ -36,7 +36,7 @@ class ConsulOperations(port: Int) {
     fun registerService(
         extension: EchoServiceExtension,
         id: String = UUID.randomUUID().toString(),
-        name: String = "sample",
+        name: String,
         registerDefaultCheck: Boolean = false,
         tags: List<String> = listOf("a")
     ) = registerService(id, name, extension.container.ipAddress(), EchoContainer.PORT, registerDefaultCheck, tags)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -2,6 +2,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.config.consul
 
 import com.ecwid.consul.v1.ConsulClient
 import com.ecwid.consul.v1.agent.model.NewService
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
 import java.util.UUID
 
 class ConsulOperations(port: Int) {
@@ -30,6 +31,14 @@ class ConsulOperations(port: Int) {
         client.agentServiceRegister(service)
         return service.id
     }
+
+    fun registerService(
+        container: EchoContainer,
+        id: String = UUID.randomUUID().toString(),
+        name: String = "sample",
+        registerDefaultCheck: Boolean = false,
+        tags: List<String> = listOf("a")
+    ) = registerService(id, name, container.ipAddress(), EchoContainer.PORT, registerDefaultCheck, tags)
 
     fun deregisterService(id: String) {
         client.agentServiceDeregister(id)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -2,8 +2,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.config.consul
 
 import com.ecwid.consul.v1.ConsulClient
 import com.ecwid.consul.v1.agent.model.NewService
-import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
-import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.ServiceExtension
 import java.util.UUID
 
 class ConsulOperations(port: Int) {
@@ -34,12 +33,12 @@ class ConsulOperations(port: Int) {
     }
 
     fun registerService(
-        extension: EchoServiceExtension,
+        extension: ServiceExtension,
         id: String = UUID.randomUUID().toString(),
         name: String,
         registerDefaultCheck: Boolean = false,
         tags: List<String> = listOf("a")
-    ) = registerService(id, name, extension.container.ipAddress(), EchoContainer.PORT, registerDefaultCheck, tags)
+    ) = registerService(id, name, extension.container.ipAddress(), extension.container.port(), registerDefaultCheck, tags)
 
     fun deregisterService(id: String) {
         client.agentServiceDeregister(id)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -3,6 +3,7 @@ package pl.allegro.tech.servicemesh.envoycontrol.config.consul
 import com.ecwid.consul.v1.ConsulClient
 import com.ecwid.consul.v1.agent.model.NewService
 import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoContainer
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
 import java.util.UUID
 
 class ConsulOperations(port: Int) {
@@ -33,12 +34,12 @@ class ConsulOperations(port: Int) {
     }
 
     fun registerService(
-        container: EchoContainer,
+        extension: EchoServiceExtension,
         id: String = UUID.randomUUID().toString(),
         name: String = "sample",
         registerDefaultCheck: Boolean = false,
         tags: List<String> = listOf("a")
-    ) = registerService(id, name, container.ipAddress(), EchoContainer.PORT, registerDefaultCheck, tags)
+    ) = registerService(id, name, extension.container.ipAddress(), EchoContainer.PORT, registerDefaultCheck, tags)
 
     fun deregisterService(id: String) {
         client.agentServiceDeregister(id)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulSetup.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulSetup.kt
@@ -12,5 +12,5 @@ class ConsulSetup(
 ) {
     val container: ConsulContainer = ConsulContainer(consulConfig.dc, port, consulConfig.id, consulConfig)
         .withNetwork(network)
-    val consulOperations = ConsulOperations(port)
+    val operations = ConsulOperations(port)
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoContainer.kt
@@ -5,7 +5,7 @@ import org.testcontainers.containers.wait.strategy.Wait
 import pl.allegro.tech.servicemesh.envoycontrol.config.testcontainers.GenericContainer
 import java.util.UUID
 
-class EchoContainer : GenericContainer<EchoContainer>("hashicorp/http-echo:latest") {
+class EchoContainer : GenericContainer<EchoContainer>("hashicorp/http-echo:latest"), ServiceContainer {
 
     val response = UUID.randomUUID().toString()
 
@@ -18,6 +18,8 @@ class EchoContainer : GenericContainer<EchoContainer>("hashicorp/http-echo:lates
     }
 
     fun address(): String = "${ipAddress()}:$PORT"
+
+    override fun port() = PORT
 
     companion object {
         const val PORT = 5678

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoServiceExtension.kt
@@ -1,6 +1,3 @@
 package pl.allegro.tech.servicemesh.envoycontrol.config.echo
 
-class EchoServiceExtension : ServiceExtension(EchoContainer()) {
-
-    override val container: EchoContainer = super.container as EchoContainer
-}
+class EchoServiceExtension : ServiceExtension<EchoContainer>(EchoContainer())

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/EchoServiceExtension.kt
@@ -1,24 +1,6 @@
 package pl.allegro.tech.servicemesh.envoycontrol.config.echo
 
-import org.junit.jupiter.api.extension.AfterAllCallback
-import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.ExtensionContext
+class EchoServiceExtension : ServiceExtension(EchoContainer()) {
 
-class EchoServiceExtension : BeforeAllCallback, AfterAllCallback {
-
-    val container = EchoContainer()
-    var started = false
-
-    override fun beforeAll(context: ExtensionContext?) {
-        if (started) {
-            return
-        }
-
-        container.start()
-        started = true
-    }
-
-    override fun afterAll(context: ExtensionContext?) {
-        container.stop()
-    }
+    override val container: EchoContainer = super.container as EchoContainer
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceContainer.kt
@@ -1,0 +1,12 @@
+package pl.allegro.tech.servicemesh.envoycontrol.config.echo
+
+interface ServiceContainer {
+
+    fun ipAddress(): String
+
+    fun port(): Int
+
+    fun start()
+
+    fun stop()
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceExtension.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-open class ServiceExtension(open val container: ServiceContainer) : BeforeAllCallback, AfterAllCallback {
+open class ServiceExtension<T : ServiceContainer>(val container: T) : BeforeAllCallback, AfterAllCallback {
 
     var started = false
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/echo/ServiceExtension.kt
@@ -1,0 +1,23 @@
+package pl.allegro.tech.servicemesh.envoycontrol.config.echo
+
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+open class ServiceExtension(open val container: ServiceContainer) : BeforeAllCallback, AfterAllCallback {
+
+    var started = false
+
+    override fun beforeAll(context: ExtensionContext) {
+        if (started) {
+            return
+        }
+
+        container.start()
+        started = true
+    }
+
+    override fun afterAll(context: ExtensionContext) {
+        container.stop()
+    }
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.testcontainers.containers.Network
 import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyConfig
 import pl.allegro.tech.servicemesh.envoycontrol.config.RandomConfigFile
-import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.ServiceExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 import pl.allegro.tech.servicemesh.envoycontrol.logger
 
 class EnvoyExtension(
     envoyControl: EnvoyControlExtension,
-    private val localService: EchoServiceExtension? = null,
+    private val localService: ServiceExtension? = null,
     config: EnvoyConfig = RandomConfigFile
 ) : BeforeAllCallback, AfterAllCallback {
 
@@ -29,7 +29,7 @@ class EnvoyExtension(
     val ingressOperations: IngressOperations = IngressOperations(container)
     val egressOperations: EgressOperations = EgressOperations(container)
 
-    override fun beforeAll(context: ExtensionContext?) {
+    override fun beforeAll(context: ExtensionContext) {
         if (localService != null && !localService.started) {
             localService.beforeAll(context)
         }
@@ -42,7 +42,7 @@ class EnvoyExtension(
         }
     }
 
-    override fun afterAll(context: ExtensionContext?) {
+    override fun afterAll(context: ExtensionContext) {
         container.stop()
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
@@ -4,14 +4,16 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.testcontainers.containers.Network
-import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.EnvoyConfig
 import pl.allegro.tech.servicemesh.envoycontrol.config.RandomConfigFile
 import pl.allegro.tech.servicemesh.envoycontrol.config.echo.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
 import pl.allegro.tech.servicemesh.envoycontrol.logger
 
 class EnvoyExtension(
     envoyControl: EnvoyControlExtension,
-    private val localService: EchoServiceExtension? = null
+    private val localService: EchoServiceExtension? = null,
+    config: EnvoyConfig = RandomConfigFile
 ) : BeforeAllCallback, AfterAllCallback {
 
     companion object {
@@ -19,9 +21,9 @@ class EnvoyExtension(
     }
 
     val container: EnvoyContainer = EnvoyContainer(
-            RandomConfigFile,
-            { localService?.container?.ipAddress() ?: "127.0.0.1" },
-            envoyControl.app.grpcPort
+        config,
+        { localService?.container?.ipAddress() ?: "127.0.0.1" },
+        envoyControl.app.grpcPort
     ).withNetwork(Network.SHARED)
 
     val ingressOperations: IngressOperations = IngressOperations(container)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
@@ -12,7 +12,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.logger
 
 class EnvoyExtension(
     envoyControl: EnvoyControlExtension,
-    private val localService: ServiceExtension? = null,
+    private val localService: ServiceExtension<*>? = null,
     config: EnvoyConfig = RandomConfigFile
 ) : BeforeAllCallback, AfterAllCallback {
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/redirect/RedirectServiceContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/redirect/RedirectServiceContainer.kt
@@ -1,12 +1,13 @@
 package pl.allegro.tech.servicemesh.envoycontrol.config.redirect
 
 import pl.allegro.tech.servicemesh.envoycontrol.config.BaseEnvoyTest
+import pl.allegro.tech.servicemesh.envoycontrol.config.echo.ServiceContainer
 import pl.allegro.tech.servicemesh.envoycontrol.config.testcontainers.GenericContainer
 import java.util.UUID
 
 class RedirectServiceContainer(
     private val redirectTo: String
-) : GenericContainer<RedirectServiceContainer>("schmunk42/nginx-redirect:latest") {
+) : GenericContainer<RedirectServiceContainer>("schmunk42/nginx-redirect:latest"), ServiceContainer {
 
     val response = UUID.randomUUID().toString()
 
@@ -22,6 +23,8 @@ class RedirectServiceContainer(
     }
 
     fun address(): String = "${ipAddress()}:$PORT"
+
+    override fun port() = PORT
 
     companion object {
         const val PORT = 80

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/ConsulRpcLimitReachedTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/ConsulRpcLimitReachedTest.kt
@@ -61,7 +61,7 @@ internal class ConsulRpcLimitReachedTest : ReliabilityTest() {
 
     private fun rpcLimitReached() {
         untilAsserted {
-            val limitReached = burstRpcLimit(lowRpcConsulClient.consulOperations)
+            val limitReached = burstRpcLimit(lowRpcConsulClient.operations)
             assertThat(limitReached).isEqualTo(true)
         }
     }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/DcCutOffTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/DcCutOffTest.kt
@@ -109,7 +109,7 @@ class DcCutOffTest : ReliabilityTest() {
         from: List<ConsulSetup>,
         operation: ModifyConnection
     ) {
-        val peers = to[0].consulOperations.peers().map { ip -> ip.split(":")[0] }
+        val peers = to[0].operations.peers().map { ip -> ip.split(":")[0] }
         peers.forEach { ip ->
             from.forEach { consul ->
                 if (operation == ModifyConnection.BLOCK) {

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/LocalConsulAgentDownTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/LocalConsulAgentDownTest.kt
@@ -32,7 +32,7 @@ internal class LocalConsulAgentDownTest : ReliabilityTest() {
     @Test
     fun `is resilient to transient unavailability of target service's local Consul agent`() {
         // given
-        registerService(name = "echo", container = echoContainer, consulOps = consulAgentInDc1.consulOperations, registerDefaultCheck = true)
+        registerService(name = "echo", container = echoContainer, consulOps = consulAgentInDc1.operations, registerDefaultCheck = true)
         // then
         assertReachableThroughEnvoy("echo")
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/LocalConsulAgentToMasterCutOff.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/reliability/LocalConsulAgentToMasterCutOff.kt
@@ -17,7 +17,7 @@ internal class LocalConsulAgentToMasterCutOff : ReliabilityTest() {
         }
 
         // and
-        registerService(name = "service-2", consulOps = consulAgentInDc1.consulOperations)
+        registerService(name = "service-2", consulOps = consulAgentInDc1.operations)
 
         // then
         holdAssertionsTrue {


### PR DESCRIPTION
This PR migrates 8 additional tests to the new approach presented in #143.

10 tests in total are migrated at the moment. Their execution time since the migration to the new approach changed from 2m10s to 3m 11s (46% increase). My next task will be to share containers between test classes and to bring the execution time below the original 2m10s.