### PR TITLE
Pooling containers between tests

### DIFF
--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/InternalRedirectTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/InternalRedirectTest.kt
@@ -8,10 +8,10 @@ import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
 import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
 import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
 import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
-import pl.allegro.tech.servicemesh.envoycontrol.config.service.EchoServiceExtension
-import pl.allegro.tech.servicemesh.envoycontrol.config.service.ServiceExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.service.EchoServiceExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.service.GenericServiceExtension
 import pl.allegro.tech.servicemesh.envoycontrol.config.service.RedirectServiceContainer
 import java.net.UnknownHostException
 
@@ -39,7 +39,7 @@ class InternalRedirectTest {
 
         @JvmField
         @RegisterExtension
-        val redirectService = ServiceExtension(RedirectServiceContainer(redirectTo = "service-1"))
+        val redirectService = GenericServiceExtension(RedirectServiceContainer(redirectTo = "service-1"))
     }
 
     @Test

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
@@ -31,7 +31,7 @@ class OutlierDetectionTest {
 
         @JvmField
         @RegisterExtension
-        val unhealthyService = EchoServiceExtension()
+        val unhealthyService = EchoServiceExtension(shared = false)
 
         @JvmField
         @RegisterExtension

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/OutlierDetectionTest.kt
@@ -31,7 +31,7 @@ class OutlierDetectionTest {
 
         @JvmField
         @RegisterExtension
-        val unhealthyService = EchoServiceExtension(shared = false)
+        val unhealthyService = EchoServiceExtension()
 
         @JvmField
         @RegisterExtension
@@ -41,10 +41,10 @@ class OutlierDetectionTest {
     @Test
     fun `should not send requests to instance when outlier check failed`() {
         // given
-        val unhealthyIp = unhealthyService.container.ipAddress()
+        val unhealthyIp = unhealthyService.container().ipAddress()
         consul.server.operations.registerService(healthyService, name = "echo")
         consul.server.operations.registerService(unhealthyService, name = "echo")
-        unhealthyService.container.stop()
+        unhealthyService.container().stop()
 
         untilAsserted {
             // when

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RetryPolicyTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/RetryPolicyTest.kt
@@ -37,7 +37,7 @@ class RetryPolicyTest {
     @Test
     fun `should retry request 3 times when application is down`() {
         // given
-        service.container.stop()
+        service.container().stop()
 
         // when
         envoy.ingressOperations.callLocalService(

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
@@ -20,11 +20,11 @@ interface ServiceTagsAndCanaryTestBase {
 
         @JvmField
         @RegisterExtension
-        val loremCanaryService = EchoServiceExtension()
+        val loremCanaryService = EchoServiceExtension(shared = false)
 
         @JvmField
         @RegisterExtension
-        val ipsumRegularService = EchoServiceExtension()
+        val ipsumRegularService = EchoServiceExtension(shared = false)
     }
 
     fun consul(): ConsulExtension

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ServiceTagsAndCanaryTestBase.kt
@@ -20,11 +20,11 @@ interface ServiceTagsAndCanaryTestBase {
 
         @JvmField
         @RegisterExtension
-        val loremCanaryService = EchoServiceExtension(shared = false)
+        val loremCanaryService = EchoServiceExtension()
 
         @JvmField
         @RegisterExtension
-        val ipsumRegularService = EchoServiceExtension(shared = false)
+        val ipsumRegularService = EchoServiceExtension()
     }
 
     fun consul(): ConsulExtension
@@ -115,7 +115,7 @@ interface ServiceTagsAndCanaryTestBase {
     }
 
     fun callStats() = CallStats(listOf(
-            loremCanaryService.container, loremRegularService.container, ipsumRegularService.container
+            loremCanaryService.container(), loremRegularService.container(), ipsumRegularService.container()
     ))
 
     fun callEchoServiceRepeatedly(
@@ -140,9 +140,9 @@ interface ServiceTagsAndCanaryTestBase {
     }
 
     val CallStats.loremCanaryHits: Int
-        get() = this.hits(loremCanaryService.container)
+        get() = this.hits(loremCanaryService.container())
     val CallStats.loremRegularHits: Int
-        get() = this.hits(loremRegularService.container)
+        get() = this.hits(loremRegularService.container())
     val CallStats.ipsumRegularHits: Int
-        get() = this.hits(ipsumRegularService.container)
+        get() = this.hits(ipsumRegularService.container())
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/assertions/ResponseAssertions.kt
@@ -19,7 +19,7 @@ fun ObjectAssert<Response>.isUnreachable(): ObjectAssert<Response> {
 
 fun ObjectAssert<Response>.isFrom(echoServiceExtension: EchoServiceExtension): ObjectAssert<Response> {
     matches {
-        it.body()?.use { it.string().contains(echoServiceExtension.container.response) } ?: false
+        it.body()?.use { it.string().contains(echoServiceExtension.container().response) } ?: false
     }
     return this
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
@@ -16,7 +16,7 @@ class ConsulExtension : BeforeAllCallback, AfterAllCallback, AfterEachCallback {
     }
 
     val server = SHARED_CONSUL
-    var started = false
+    private var started = false
 
     override fun beforeAll(context: ExtensionContext) {
         if (started) {

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulExtension.kt
@@ -8,10 +8,14 @@ import org.testcontainers.containers.Network
 
 class ConsulExtension : BeforeAllCallback, AfterAllCallback, AfterEachCallback {
 
-    val server: ConsulSetup = ConsulSetup(
+    companion object {
+        private val SHARED_CONSUL = ConsulSetup(
             Network.SHARED,
             ConsulServerConfig(1, "dc1", expectNodes = 1)
-    )
+        )
+    }
+
+    val server = SHARED_CONSUL
     var started = false
 
     override fun beforeAll(context: ExtensionContext) {
@@ -28,6 +32,5 @@ class ConsulExtension : BeforeAllCallback, AfterAllCallback, AfterEachCallback {
     }
 
     override fun afterAll(context: ExtensionContext) {
-        server.container.stop()
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/consul/ConsulOperations.kt
@@ -38,7 +38,7 @@ class ConsulOperations(port: Int) {
         name: String,
         registerDefaultCheck: Boolean = false,
         tags: List<String> = listOf("a")
-    ) = registerService(id, name, extension.container.ipAddress(), extension.container.port(), registerDefaultCheck, tags)
+    ) = registerService(id, name, extension.container().ipAddress(), extension.container().port(), registerDefaultCheck, tags)
 
     fun deregisterService(id: String) {
         client.agentServiceDeregister(id)

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EgressOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EgressOperations.kt
@@ -52,7 +52,7 @@ class EgressOperations(val envoy: EnvoyContainer) {
     fun callServiceWithOriginalDst(service: EchoServiceExtension) =
         callWithHostHeader(
             "envoy-original-destination",
-            mapOf("x-envoy-original-dst-host" to service.container.address()),
+            mapOf("x-envoy-original-dst-host" to service.container().address()),
             ""
         )
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyExtension.kt
@@ -22,7 +22,7 @@ class EnvoyExtension(
 
     val container: EnvoyContainer = EnvoyContainer(
         config,
-        { localService?.container?.ipAddress() ?: "127.0.0.1" },
+        { localService?.container()?.ipAddress() ?: "127.0.0.1" },
         envoyControl.app.grpcPort
     ).withNetwork(Network.SHARED)
 
@@ -30,9 +30,7 @@ class EnvoyExtension(
     val egressOperations: EgressOperations = EgressOperations(container)
 
     override fun beforeAll(context: ExtensionContext) {
-        if (localService != null && !localService.started) {
-            localService.beforeAll(context)
-        }
+        localService?.beforeAll(context)
 
         try {
             container.start()

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoycontrol/EnvoyControlExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoycontrol/EnvoyControlExtension.kt
@@ -18,9 +18,7 @@ class EnvoyControlExtension(private val consul: ConsulExtension, val app: EnvoyC
         ))
 
     override fun beforeAll(context: ExtensionContext) {
-        if (!consul.started) {
-            consul.beforeAll(context)
-        }
+        consul.beforeAll(context)
         app.run()
         waitUntilHealthy()
     }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/EchoServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/EchoServiceExtension.kt
@@ -1,11 +1,35 @@
 package pl.allegro.tech.servicemesh.envoycontrol.config.service
 
-class EchoServiceExtension(shared: Boolean = true) : ServiceExtension<EchoContainer>(
-    if (shared) SHARED_CONTAINER else EchoContainer(),
-    shared = shared
-) {
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.LinkedList
+import java.util.Queue
+
+class EchoServiceExtension : ServiceExtension<EchoContainer> {
 
     companion object {
-        private val SHARED_CONTAINER = EchoContainer()
+        private val freeContainers: Queue<EchoContainer> = LinkedList()
+        private val usedContainers = mutableMapOf<EchoServiceExtension, EchoContainer>()
+    }
+
+    var started = false
+    private var container: EchoContainer? = null
+
+    override fun container() = container!!
+
+    override fun beforeAll(context: ExtensionContext) {
+        if (started) {
+            return
+        }
+
+        container = freeContainers.poll()?: EchoContainer()
+        usedContainers[this] = container!!
+
+        container!!.start()
+        started = true
+    }
+
+    override fun afterAll(context: ExtensionContext) {
+        val container = usedContainers.remove(this)!!
+        freeContainers.offer(container)
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/EchoServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/EchoServiceExtension.kt
@@ -1,3 +1,11 @@
 package pl.allegro.tech.servicemesh.envoycontrol.config.service
 
-class EchoServiceExtension : ServiceExtension<EchoContainer>(EchoContainer())
+class EchoServiceExtension(shared: Boolean = true) : ServiceExtension<EchoContainer>(
+    if (shared) SHARED_CONTAINER else EchoContainer(),
+    shared = shared
+) {
+
+    companion object {
+        private val SHARED_CONTAINER = EchoContainer()
+    }
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/GenericServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/GenericServiceExtension.kt
@@ -1,0 +1,23 @@
+package pl.allegro.tech.servicemesh.envoycontrol.config.service
+
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class GenericServiceExtension<T : ServiceContainer>(private val container: T) : ServiceExtension<T> {
+
+    private var started = false
+
+    override fun container() = container
+
+    override fun beforeAll(context: ExtensionContext) {
+        if (started) {
+            return
+        }
+
+        container.start()
+        started = true
+    }
+
+    override fun afterAll(context: ExtensionContext) {
+        container.stop()
+    }
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/ServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/ServiceExtension.kt
@@ -2,25 +2,8 @@ package pl.allegro.tech.servicemesh.envoycontrol.config.service
 
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
-import org.junit.jupiter.api.extension.ExtensionContext
 
-open class ServiceExtension<T : ServiceContainer>(val container: T, private val shared: Boolean = false)
-    : BeforeAllCallback, AfterAllCallback {
+interface ServiceExtension<T : ServiceContainer> : BeforeAllCallback, AfterAllCallback {
 
-    var started = false
-
-    override fun beforeAll(context: ExtensionContext) {
-        if (started) {
-            return
-        }
-
-        container.start()
-        started = true
-    }
-
-    override fun afterAll(context: ExtensionContext) {
-        if (!shared) {
-            container.stop()
-        }
-    }
+    fun container(): T
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/ServiceExtension.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/service/ServiceExtension.kt
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-open class ServiceExtension<T : ServiceContainer>(val container: T) : BeforeAllCallback, AfterAllCallback {
+open class ServiceExtension<T : ServiceContainer>(val container: T, private val shared: Boolean = false)
+    : BeforeAllCallback, AfterAllCallback {
 
     var started = false
 
@@ -18,6 +19,8 @@ open class ServiceExtension<T : ServiceContainer>(val container: T) : BeforeAllC
     }
 
     override fun afterAll(context: ExtensionContext) {
-        container.stop()
+        if (!shared) {
+            container.stop()
+        }
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/sharing/ContainerPool.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/sharing/ContainerPool.kt
@@ -1,0 +1,26 @@
+package pl.allegro.tech.servicemesh.envoycontrol.config.sharing
+
+import org.testcontainers.containers.GenericContainer
+import java.util.LinkedList
+import java.util.Queue
+
+class ContainerPool<OWNER, CONTAINER : GenericContainer<*>>(private val containerFactory: () -> CONTAINER) {
+
+    private val freeContainers: Queue<CONTAINER> = LinkedList()
+    private val usedContainers = mutableMapOf<OWNER, CONTAINER>()
+
+    fun acquire(owner: OWNER): CONTAINER {
+        val container = freeContainers.poll() ?: containerFactory()
+        container.start()
+
+        usedContainers[owner] = container
+        return container
+    }
+
+    fun release(owner: OWNER) {
+        val container = usedContainers.remove(owner) ?: throw ContainerNotFound(owner.toString())
+        freeContainers.add(container)
+    }
+
+    class ContainerNotFound(owner: String) : RuntimeException("container owned by $owner not found")
+}


### PR DESCRIPTION
This PR introduced sharing some of the containers between test classes:
* `ConsulExtension` creates a single shared Consul container instance for all the tests. This extension can only be created once in a test class at the moment.
* `EchoServiceExtension` uses `ContainerPool` to reuse echo containers between the tests. `EchoServiceExtension` can be defined multiple times in a single test class.

The execution time for 10 tests went down from `3m 11s` to `1m 36s`. It was `2m 10s` in the old approach with base classes instead of extensions.

`ContainerPool` currently only supports pooling containers that have no configuration, that is container instances don't differ. This can be developed further in the future. Once we migrate tests that require multiple `ConsulExtension` instances we should change the sharing mechanism there to a configuration-aware container pool.