### PR TITLE
Fix unnecessary EDS responses when state between services is inconsistent

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/endpoints/EnvoyEndpointsFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/endpoints/EnvoyEndpointsFactory.kt
@@ -37,9 +37,7 @@ class EnvoyEndpointsFactory(
                         val locality = it.locality
                         val cluster = it.cluster
 
-                        it.servicesState.get(serviceName)?.let {
-                            createEndpointsGroup(it, cluster, toEnvoyPriority(locality))
-                        }
+                        createEndpointsGroup(it.servicesState[serviceName], cluster, toEnvoyPriority(locality))
                     }
 
                 ClusterLoadAssignment.newBuilder()
@@ -50,13 +48,15 @@ class EnvoyEndpointsFactory(
     }
 
     private fun createEndpointsGroup(
-        serviceInstances: ServiceInstances,
+        serviceInstances: ServiceInstances?,
         zone: String,
         priority: Int
     ): LocalityLbEndpoints =
         LocalityLbEndpoints.newBuilder()
             .setLocality(Locality.newBuilder().setZone(zone).build())
-            .addAllLbEndpoints(serviceInstances.instances.map { createLbEndpoint(it, serviceInstances.serviceName) })
+            .addAllLbEndpoints(serviceInstances?.instances?.map {
+                createLbEndpoint(it, serviceInstances.serviceName)
+            } ?: emptyList())
             .setPriority(priority)
             .build()
 

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/endpoints/EnvoyEndpointsFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/endpoints/EnvoyEndpointsFactory.kt
@@ -33,7 +33,7 @@ class EnvoyEndpointsFactory(
         return clusters
             .map { serviceName ->
                 val localityLbEndpoints = multiClusterState
-                    .mapNotNull {
+                    .map {
                         val locality = it.locality
                         val cluster = it.cluster
 

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -593,7 +593,7 @@ class SnapshotUpdaterTest {
     ): GlobalSnapshot {
         val endpoints = this.endpoints.resources()[clusterName]
         assertThat(endpoints).isNotNull
-        assertThat(endpoints!!.endpointsList.map { it.locality.zone }.toSet()).isEqualTo(zones)
+        assertThat(endpoints!!.endpointsList.map { it.locality.zone }.toSet()).containsAll(zones)
         assertThat(endpoints.endpointsList.flatMap { it.lbEndpointsList }).isEmpty()
         return this
     }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -94,8 +94,8 @@ class SnapshotUpdaterTest {
         // groups are generated foreach element in SnapshotCache.groups(), so we need to initialize them
         val groups = listOf(
             AllServicesGroup(communicationMode = XDS), groupWithProxy, groupWithServiceName,
-                groupOf(services = serviceDependencies("existingService1")),
-                groupOf(services = serviceDependencies("existingService2"))
+            groupOf(services = serviceDependencies("existingService1")),
+            groupOf(services = serviceDependencies("existingService2"))
         )
         groups.forEach {
             cache.setSnapshot(it, uninitializedSnapshot)
@@ -205,8 +205,8 @@ class SnapshotUpdaterTest {
     fun `should not crash on bad snapshot generation`() {
         // given
         val servicesGroup = AllServicesGroup(
-                communicationMode = ADS,
-                serviceName = "example-service"
+            communicationMode = ADS,
+            serviceName = "example-service"
         )
         val cache = FailingMockCache()
         cache.setSnapshot(servicesGroup, null)
@@ -214,14 +214,14 @@ class SnapshotUpdaterTest {
 
         // when
         updater.start(
-                Flux.just(MultiClusterState.empty())
+            Flux.just(MultiClusterState.empty())
         ).blockFirst()
 
         // then
         val snapshot = cache.getSnapshot(servicesGroup)
         assertThat(snapshot).isEqualTo(null)
         assertThat(simpleMeterRegistry.find("snapshot-updater.services.example-service.updates.errors")
-                .counter()?.count()).isEqualTo(1.0)
+            .counter()?.count()).isEqualTo(1.0)
     }
 
     @Test
@@ -263,6 +263,93 @@ class SnapshotUpdaterTest {
     }
 
     @Test
+    fun `should not change EDS when remote doesn't have state of service`() {
+        // given
+        val cache = MockCache()
+        val allServicesGroup = AllServicesGroup(communicationMode = ADS)
+        val groups = listOf(allServicesGroup)
+        val updater = snapshotUpdater(
+            cache = cache,
+            properties = SnapshotProperties().apply {
+                stateSampleDuration = Duration.ZERO
+            },
+            groups = groups
+        )
+
+        val clusterLocal = ClusterState(
+            ServicesState(
+                serviceNameToInstances = mapOf(
+                    "service" to ServiceInstances("service", setOf(ServiceInstance(
+                        id = "id",
+                        tags = setOf("envoy"),
+                        address = "127.0.0.3",
+                        port = 4444
+                    ))),
+                    "service2" to ServiceInstances("service2", setOf())
+                )
+            ),
+            Locality.LOCAL, "cluster"
+        ).toMultiClusterState()
+
+        val clusterRemote1 = ClusterState(
+            ServicesState(
+                serviceNameToInstances = mapOf(
+                    "service" to ServiceInstances("service", setOf()),
+                    "service2" to ServiceInstances("service2", setOf())
+                )
+            ),
+            Locality.REMOTE, "cluster2"
+        ).toMultiClusterState()
+
+        val clusterRemote2 = ClusterState(
+            ServicesState(
+                serviceNameToInstances = mapOf(
+                    "service" to ServiceInstances("service", setOf())
+                )
+            ),
+            Locality.REMOTE, "cluster2"
+        ).toMultiClusterState()
+
+        // when
+        val results = updater
+            .services(Flux
+                .just(
+                    clusterLocal,
+                    clusterRemote1)
+                .delayElements(Duration.ofMillis(10))
+            )
+            .collectList().block()!!
+
+        // when
+        val results2 = updater
+            .services(Flux
+                .just(
+                    clusterLocal,
+                    clusterRemote2)
+                .delayElements(Duration.ofMillis(10))
+            )
+            .collectList().block()!!
+
+        // then
+        results[0].adsSnapshot!!
+            .hasTheSameClusters(results2[0].adsSnapshot!!)
+            .hasTheSameEndpoints(results2[0].adsSnapshot!!)
+            .hasTheSameSecuredClusters(results2[0].adsSnapshot!!)
+        results[0].xdsSnapshot!!
+            .hasTheSameClusters(results2[0].xdsSnapshot!!)
+            .hasTheSameEndpoints(results2[0].xdsSnapshot!!)
+            .hasTheSameSecuredClusters(results2[0].xdsSnapshot!!)
+        results[1].adsSnapshot!!
+            .hasTheSameClusters(results2[1].adsSnapshot!!)
+            .hasTheSameEndpoints(results2[1].adsSnapshot!!)
+            .hasTheSameSecuredClusters(results2[1].adsSnapshot!!)
+        results[1].xdsSnapshot!!
+            .hasTheSameClusters(results2[1].xdsSnapshot!!)
+            .hasTheSameEndpoints(results2[1].xdsSnapshot!!)
+            .hasTheSameSecuredClusters(results2[1].xdsSnapshot!!)
+    }
+
+    @Test
     fun `should not remove clusters`() {
         // given
         val cache = MockCache()
@@ -300,10 +387,10 @@ class SnapshotUpdaterTest {
 
         results[1].adsSnapshot!!
             .hasHttp2Cluster("service")
-            .hasEmptyEndpoints("service")
+            .hasAnEmptyLocalityEndpointsList("service", setOf("cluster"))
         results[1].xdsSnapshot!!
             .hasHttp2Cluster("service")
-            .hasEmptyEndpoints("service")
+            .hasAnEmptyLocalityEndpointsList("service", setOf("cluster"))
     }
 
     @Test
@@ -499,6 +586,17 @@ class SnapshotUpdaterTest {
         return this
     }
 
+    private fun GlobalSnapshot.hasAnEmptyLocalityEndpointsList(
+        clusterName: String,
+        zones: Set<String>
+    ): GlobalSnapshot {
+        val endpoints = this.endpoints.resources()[clusterName]
+        assertThat(endpoints).isNotNull
+        assertThat(endpoints!!.endpointsList.map { it.locality.zone }.toSet()).isEqualTo(zones)
+        assertThat(endpoints!!.endpointsList.flatMap { it.lbEndpointsList }).isEmpty()
+        return this
+    }
+
     private fun GlobalSnapshot.hasAnEndpoint(clusterName: String, ip: String, port: Int): GlobalSnapshot {
         val endpoints = this.endpoints.resources()[clusterName]
         assertThat(endpoints).isNotNull
@@ -507,10 +605,21 @@ class SnapshotUpdaterTest {
         return this
     }
 
-    private fun GlobalSnapshot.hasEmptyEndpoints(clusterName: String): GlobalSnapshot {
-        val endpoints = this.endpoints.resources()[clusterName]
-        assertThat(endpoints).isNotNull
-        assertThat(endpoints!!.endpointsList).isEmpty()
+    private fun GlobalSnapshot.hasTheSameClusters(other: GlobalSnapshot): GlobalSnapshot {
+        val clusters = this.clusters.resources()
+        assertThat(clusters).isEqualTo(other.clusters.resources())
+        return this
+    }
+
+    private fun GlobalSnapshot.hasTheSameEndpoints(other: GlobalSnapshot): GlobalSnapshot {
+        val endpoints = this.endpoints.resources()
+        assertThat(endpoints).isEqualTo(other.endpoints.resources())
+        return this
+    }
+
+    private fun GlobalSnapshot.hasTheSameSecuredClusters(other: GlobalSnapshot): GlobalSnapshot {
+        val securedClusters = this.securedClusters.resources()
+        assertThat(securedClusters).isEqualTo(other.securedClusters.resources())
         return this
     }
 

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -286,23 +286,23 @@ class SnapshotUpdaterTest {
                         address = "127.0.0.3",
                         port = 4444
                     ))),
-                    "service2" to ServiceInstances("service2", setOf())
+                    "servicePresentInJustOneRemote" to ServiceInstances("servicePresentInJustOneRemote", setOf())
                 )
             ),
             Locality.LOCAL, "cluster"
         ).toMultiClusterState()
 
-        val clusterRemote1 = ClusterState(
+        val remoteClusterWithBothServices = ClusterState(
             ServicesState(
                 serviceNameToInstances = mapOf(
                     "service" to ServiceInstances("service", setOf()),
-                    "service2" to ServiceInstances("service2", setOf())
+                    "servicePresentInJustOneRemote" to ServiceInstances("servicePresentInJustOneRemote", setOf())
                 )
             ),
             Locality.REMOTE, "cluster2"
         ).toMultiClusterState()
 
-        val clusterRemote2 = ClusterState(
+        val remoteClusterWithJustOneService = ClusterState(
             ServicesState(
                 serviceNameToInstances = mapOf(
                     "service" to ServiceInstances("service", setOf())
@@ -312,42 +312,42 @@ class SnapshotUpdaterTest {
         ).toMultiClusterState()
 
         // when
-        val results = updater
+        val resultsRemoteWithBothServices = updater
             .services(Flux
                 .just(
                     clusterLocal,
-                    clusterRemote1)
+                    remoteClusterWithBothServices)
                 .delayElements(Duration.ofMillis(10))
             )
             .collectList().block()!!
 
         // when
-        val results2 = updater
+        val resultsRemoteWithJustOneService = updater
             .services(Flux
                 .just(
                     clusterLocal,
-                    clusterRemote2)
+                    remoteClusterWithJustOneService)
                 .delayElements(Duration.ofMillis(10))
             )
             .collectList().block()!!
 
         // then
-        results[0].adsSnapshot!!
-            .hasTheSameClusters(results2[0].adsSnapshot!!)
-            .hasTheSameEndpoints(results2[0].adsSnapshot!!)
-            .hasTheSameSecuredClusters(results2[0].adsSnapshot!!)
-        results[0].xdsSnapshot!!
-            .hasTheSameClusters(results2[0].xdsSnapshot!!)
-            .hasTheSameEndpoints(results2[0].xdsSnapshot!!)
-            .hasTheSameSecuredClusters(results2[0].xdsSnapshot!!)
-        results[1].adsSnapshot!!
-            .hasTheSameClusters(results2[1].adsSnapshot!!)
-            .hasTheSameEndpoints(results2[1].adsSnapshot!!)
-            .hasTheSameSecuredClusters(results2[1].adsSnapshot!!)
-        results[1].xdsSnapshot!!
-            .hasTheSameClusters(results2[1].xdsSnapshot!!)
-            .hasTheSameEndpoints(results2[1].xdsSnapshot!!)
-            .hasTheSameSecuredClusters(results2[1].xdsSnapshot!!)
+        resultsRemoteWithBothServices[0].adsSnapshot!!
+            .hasTheSameClusters(resultsRemoteWithJustOneService[0].adsSnapshot!!)
+            .hasTheSameEndpoints(resultsRemoteWithJustOneService[0].adsSnapshot!!)
+            .hasTheSameSecuredClusters(resultsRemoteWithJustOneService[0].adsSnapshot!!)
+        resultsRemoteWithBothServices[0].xdsSnapshot!!
+            .hasTheSameClusters(resultsRemoteWithJustOneService[0].xdsSnapshot!!)
+            .hasTheSameEndpoints(resultsRemoteWithJustOneService[0].xdsSnapshot!!)
+            .hasTheSameSecuredClusters(resultsRemoteWithJustOneService[0].xdsSnapshot!!)
+        resultsRemoteWithBothServices[1].adsSnapshot!!
+            .hasTheSameClusters(resultsRemoteWithJustOneService[1].adsSnapshot!!)
+            .hasTheSameEndpoints(resultsRemoteWithJustOneService[1].adsSnapshot!!)
+            .hasTheSameSecuredClusters(resultsRemoteWithJustOneService[1].adsSnapshot!!)
+        resultsRemoteWithBothServices[1].xdsSnapshot!!
+            .hasTheSameClusters(resultsRemoteWithJustOneService[1].xdsSnapshot!!)
+            .hasTheSameEndpoints(resultsRemoteWithJustOneService[1].xdsSnapshot!!)
+            .hasTheSameSecuredClusters(resultsRemoteWithJustOneService[1].xdsSnapshot!!)
     }
 
     @Test

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
+@Suppress("LargeClass")
 class SnapshotUpdaterTest {
 
     companion object {
@@ -593,7 +594,7 @@ class SnapshotUpdaterTest {
         val endpoints = this.endpoints.resources()[clusterName]
         assertThat(endpoints).isNotNull
         assertThat(endpoints!!.endpointsList.map { it.locality.zone }.toSet()).isEqualTo(zones)
-        assertThat(endpoints!!.endpointsList.flatMap { it.lbEndpointsList }).isEmpty()
+        assertThat(endpoints.endpointsList.flatMap { it.lbEndpointsList }).isEmpty()
         return this
     }
 


### PR DESCRIPTION
Let's say we have 2 instances of EC in the remote cluster. 
First instance on endpoint `state` returns:
```
{
  "serviceNameToInstances":
    {
      "echo":
        {
          "serviceName":"echo","instances":[]
        }
    }
}
```
Second instance on endpoint `state` returns:
```
{
  "serviceNameToInstances": {}
}
```
And one instance of EC in a local cluster with the state:
```
{
  "serviceNameToInstances":
    {
      "echo":
        {
          "serviceName":"echo","instances":[]
        }
    }
}
```

When local instance synchronizes with the first instance in the remote cluster it generates EDS configuration:

```
"clusterName": "echo",
    "endpoints": [
      {
        "locality": {
          "zone": "local"
        }
      },
      {
        "locality": {
          "zone": "remote"
        },
        "priority": 1
      }
    ]
```
but if it reconnects to the second cluster in remote configuration will change to:
```
"clusterName": "echo",
    "endpoints": [
      {
        "locality": {
          "zone": "local"
        }
      }
    ]
```
and because of that we would detect a change in EDS and send a new version.
Fix creates a locality for each remote dc but without any endpoint. If you have any concerns or suggestions on how to fix it please share your thoughts.