### PR TITLE
When fetching state from remote ignore services without instances don't trigger cross dc change

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteClusterStateChanges.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteClusterStateChanges.kt
@@ -1,8 +1,8 @@
 package pl.allegro.tech.servicemesh.envoycontrol.synchronization
 
 import pl.allegro.tech.servicemesh.envoycontrol.EnvoyControlProperties
-import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState
 import pl.allegro.tech.servicemesh.envoycontrol.services.ClusterStateChanges
+import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState
 import reactor.core.publisher.Flux
 
 class RemoteClusterStateChanges(

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServices.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServices.kt
@@ -6,6 +6,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.services.ClusterState
 import pl.allegro.tech.servicemesh.envoycontrol.services.Locality
 import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState
 import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState.Companion.toMultiClusterState
+import pl.allegro.tech.servicemesh.envoycontrol.services.ServicesState
 import pl.allegro.tech.servicemesh.envoycontrol.utils.measureBuffer
 import pl.allegro.tech.servicemesh.envoycontrol.utils.measureDiscardedItems
 import reactor.core.publisher.Flux
@@ -73,6 +74,7 @@ class RemoteServices(
             .getState(instance)
             .checkpoint("cross-dc-service-update-$cluster")
             .name("cross-dc-service-update-$cluster").metrics()
+            .map { ServicesState(it.serviceNameToInstances.filterValues { value -> value.instances.isNotEmpty() }) }
             .map {
                 ClusterState(it, Locality.REMOTE, cluster)
             }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServices.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServices.kt
@@ -74,7 +74,7 @@ class RemoteServices(
             .getState(instance)
             .checkpoint("cross-dc-service-update-$cluster")
             .name("cross-dc-service-update-$cluster").metrics()
-            .map { ServicesState(it.serviceNameToInstances.filterValues { value -> value.instances.isNotEmpty() }) }
+            .map { onlyServicesWithInstances(it) }
             .map {
                 ClusterState(it, Locality.REMOTE, cluster)
             }
@@ -89,6 +89,9 @@ class RemoteServices(
                 Mono.justOrEmpty(clusterStateCache[cluster])
             }
     }
+
+    private fun onlyServicesWithInstances(it: ServicesState): ServicesState =
+        ServicesState(it.serviceNameToInstances.filterValues { value -> value.instances.isNotEmpty() })
 
     private fun chooseInstance(serviceInstances: List<URI>): URI = serviceInstances.random()
 }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServicesTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/synchronization/RemoteServicesTest.kt
@@ -3,8 +3,8 @@ package pl.allegro.tech.servicemesh.envoycontrol.synchronization
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import pl.allegro.tech.servicemesh.envoycontrol.services.Locality
 import pl.allegro.tech.servicemesh.envoycontrol.services.ClusterState
+import pl.allegro.tech.servicemesh.envoycontrol.services.Locality
 import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceInstance
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceInstances
@@ -39,6 +39,21 @@ class RemoteServicesTest {
 
         assertThat(result).hasSize(1)
         assertThat(result.map { it.cluster }).contains("dc1")
+    }
+
+    @Test
+    fun `should ignore services without instances`() {
+        val service = RemoteServices(asyncClient(), SimpleMeterRegistry(), fetcher(), listOf("dc1",
+            "dc2/service-c-no-instances"))
+
+        val result = service
+            .getChanges(1)
+            .blockFirst()
+            ?: MultiClusterState.empty()
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.cluster }).contains("dc1", "dc2/service-c-no-instances")
+        result.doesntHaveServiceWithEmptyInstances("dc2/service-c-no-instances", "service-c")
     }
 
     @Test
@@ -136,6 +151,16 @@ class RemoteServicesTest {
         )
     )
 
+    private val servicesState4 = ServicesState(
+        serviceNameToInstances = mapOf(
+            "service-b" to ServiceInstances(
+                "service-b",
+                setOf(ServiceInstance("3", setOf(), "localhost", 81))
+            ),
+            "service-c" to ServiceInstances("service-c", emptySet())
+        )
+    )
+
     private val expectedSuccessfulState = setOf(
         ClusterState(servicesState1, Locality.REMOTE, "dc1/successful-states"),
         ClusterState(servicesState3, Locality.REMOTE, "dc2/second-request-failing")
@@ -154,6 +179,16 @@ class RemoteServicesTest {
         Mono.just(servicesState3), Mono.error(RuntimeException("Error fetching from dc2"))
     ).iterator()
 
+    private fun MultiClusterState.doesntHaveServiceWithEmptyInstances(
+        cluster: String,
+        serviceName: String
+    ): MultiClusterState {
+        val clusterState = this.first { it.cluster == cluster }
+        assertThat(clusterState).isNotNull
+        assertThat(clusterState.servicesState.serviceNameToInstances.keys).doesNotContain(serviceName)
+        return this
+    }
+
     private fun asyncClient(): AsyncControlPlaneClient {
         return object : AsyncControlPlaneClient {
             override fun getState(uri: URI): Mono<ServicesState> = when {
@@ -161,12 +196,13 @@ class RemoteServicesTest {
                 uri.path == "/empty" -> Mono.empty()
                 uri.path == "/successful-states" -> successfulStatesSequence.next()
                 uri.path == "/second-request-failing" -> secondStateFailingSequence.next()
+                uri.path == "/service-c-no-instances" -> Mono.just(servicesState4)
                 else -> Mono.just(
                     ServicesState(
                         serviceNameToInstances = mapOf(
                             uri.authority to ServiceInstances(
                                 uri.authority,
-                                emptySet()
+                                setOf(ServiceInstance("1", setOf(), "localhost", 80))
                             )
                         )
                     )


### PR DESCRIPTION
A state between instances of EC can change. If one instance of EC in remote dc has different state than another one it might trigger cross-cluster changes.
Instance 1 state
```
{
  "serviceNameToInstances":
    {
      "echo":
        {
          "serviceName":"echo","instances":[(instance ./.....)]
        },
        "echo2":
        {
          "serviceName":"echo","instances":[]
        }
    }
}
```
Instance 2 state
```
{
  "serviceNameToInstances":
    {
      "echo":
        {
          "serviceName":"echo","instances":[(instance ./.....)]
        }
    }
}
```
The state is the same because there is no instances of `echo2` in both instances so we shouldn't trigger any changes.

To avoid that we should filter out services with empty `ServiceInstances` to avoid triggering changes. That shouldn't affect local cluster state and problem with removing clusters because once we have service in LocalState then it will stay there. 

#163  and #159 fixes problem with unnecessary EDS/CDS responses but even after these fixes I've observed higher CPU usage caused by the number of cross dc changes.