### PR TITLE
Timeouts for wildcard dependency

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
@@ -146,9 +146,8 @@ class MetadataNodeGroup(
     }
 
     private fun hasAllServicesDependencies(metadata: NodeMetadata): Boolean {
-        return !properties.outgoingPermissions.enabled || metadata.proxySettings.outgoing.containsDependencyForService(
-            properties.outgoingPermissions.allServicesDependencies.identifier
-        )
+        return !properties.outgoingPermissions.enabled ||
+            metadata.proxySettings.outgoing.allServicesDependencies
     }
 
     private fun serviceName(metadata: NodeMetadata): String {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
@@ -295,14 +295,9 @@ data class Outgoing(
     val defaultServiceSettings: DependencySettings = DependencySettings()
 ) {
     data class TimeoutPolicy(
-        val idleTimeout: Duration = DEFAULT_IDLE_TIMEOUT,
-        val requestTimeout: Duration = DEFAULT_REQUEST_TIMEOUT
-    ) {
-        companion object {
-            val DEFAULT_IDLE_TIMEOUT: Duration = Durations.fromSeconds(120)
-            val DEFAULT_REQUEST_TIMEOUT: Duration = Durations.fromSeconds(120)
-        }
-    }
+        val idleTimeout: Duration? = null,
+        val requestTimeout: Duration? = null
+    )
 }
 
 interface Dependency

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataValidator.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataValidator.kt
@@ -81,9 +81,7 @@ class NodeMetadataValidator(
     }
 
     private fun hasAllServicesDependencies(metadata: NodeMetadata) =
-        metadata.proxySettings.outgoing.containsDependencyForService(
-            properties.outgoingPermissions.allServicesDependencies.identifier
-        )
+        metadata.proxySettings.outgoing.allServicesDependencies
 
     private fun isAllowedToHaveAllServiceDependencies(metadata: NodeMetadata) = properties
         .outgoingPermissions.servicesAllowedToUseWildcard.contains(metadata.serviceName)

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
@@ -1,6 +1,5 @@
 package pl.allegro.tech.servicemesh.envoycontrol.snapshot
 
-import com.google.protobuf.util.Durations
 import io.envoyproxy.controlplane.cache.Snapshot
 import io.envoyproxy.envoy.api.v2.Cluster
 import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment
@@ -13,16 +12,15 @@ import pl.allegro.tech.servicemesh.envoycontrol.groups.AllServicesGroup
 import pl.allegro.tech.servicemesh.envoycontrol.groups.CommunicationMode
 import pl.allegro.tech.servicemesh.envoycontrol.groups.DependencySettings
 import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
-import pl.allegro.tech.servicemesh.envoycontrol.groups.Outgoing
 import pl.allegro.tech.servicemesh.envoycontrol.groups.ServicesGroup
 import pl.allegro.tech.servicemesh.envoycontrol.services.MultiClusterState
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceInstance
 import pl.allegro.tech.servicemesh.envoycontrol.services.ServiceInstances
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.clusters.EnvoyClustersFactory
-import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes.EnvoyEgressRoutesFactory
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.endpoints.EnvoyEndpointsFactory
-import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes.EnvoyIngressRoutesFactory
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.EnvoyListenersFactory
+import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes.EnvoyEgressRoutesFactory
+import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes.EnvoyIngressRoutesFactory
 
 class EnvoySnapshotFactory(
     private val ingressRoutesFactory: EnvoyIngressRoutesFactory,
@@ -32,14 +30,6 @@ class EnvoySnapshotFactory(
     private val listenersFactory: EnvoyListenersFactory,
     private val snapshotsVersions: SnapshotsVersions,
     private val properties: SnapshotProperties,
-    private val defaultDependencySettings: DependencySettings =
-        DependencySettings(
-            handleInternalRedirect = properties.egress.handleInternalRedirect,
-            timeoutPolicy = Outgoing.TimeoutPolicy(
-                idleTimeout = Durations.fromMillis(properties.egress.commonHttp.idleTimeout.toMillis()),
-                requestTimeout = Durations.fromMillis(properties.egress.commonHttp.requestTimeout.toMillis())
-            )
-        ),
     private val meterRegistry: MeterRegistry
 ) {
     fun newSnapshot(
@@ -161,7 +151,7 @@ class EnvoySnapshotFactory(
     }
 
     private fun getDomainRouteSpecifications(group: Group): List<RouteSpecification> {
-        return group.proxySettings.outgoing.getDomainDependencies().map {
+        return group.proxySettings.outgoing.domainDependencies.map {
             RouteSpecification(
                 clusterName = it.getClusterName(),
                 routeDomain = it.getRouteDomain(),
@@ -174,20 +164,27 @@ class EnvoySnapshotFactory(
         group: Group,
         globalSnapshot: GlobalSnapshot
     ): Collection<RouteSpecification> {
+        val definedServicesRoutes = group.proxySettings.outgoing.serviceDependencies.map {
+            RouteSpecification(
+                clusterName = it.service,
+                routeDomain = it.service,
+                settings = it.settings
+            )
+        }
         return when (group) {
-            is ServicesGroup -> group.proxySettings.outgoing.getServiceDependencies().map {
-                RouteSpecification(
-                    clusterName = it.service,
-                    routeDomain = it.service,
-                    settings = it.settings
-                )
+            is ServicesGroup -> {
+                definedServicesRoutes
             }
-            is AllServicesGroup -> globalSnapshot.allServicesNames.map {
-                RouteSpecification(
-                    clusterName = it,
-                    routeDomain = it,
-                    settings = defaultDependencySettings
-                )
+            is AllServicesGroup -> {
+                val servicesNames = group.proxySettings.outgoing.serviceDependencies.map { it.service }.toSet()
+                val allServicesRoutes = globalSnapshot.allServicesNames.subtract(servicesNames).map {
+                    RouteSpecification(
+                        clusterName = it,
+                        routeDomain = it,
+                        settings = group.proxySettings.outgoing.defaultServiceSettings
+                    )
+                }
+                allServicesRoutes + definedServicesRoutes
             }
         }
     }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
@@ -99,7 +99,7 @@ class EnvoyClustersFactory(
         }
 
         return when (group) {
-            is ServicesGroup -> group.proxySettings.outgoing.getServiceDependencies().mapNotNull {
+            is ServicesGroup -> group.proxySettings.outgoing.serviceDependencies.mapNotNull {
                 clusters.get(it.service)
             }
             is AllServicesGroup -> globalSnapshot.allServicesNames.mapNotNull {
@@ -145,7 +145,7 @@ class EnvoyClustersFactory(
     }
 
     private fun getStrictDnsClustersForGroup(group: Group): List<Cluster> {
-        return group.proxySettings.outgoing.getDomainDependencies().map {
+        return group.proxySettings.outgoing.domainDependencies.map {
             strictDnsCluster(it.getClusterName(), it.getHost(), it.getPort(), it.useSsl())
         }
     }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
@@ -35,7 +35,9 @@ class MetadataNodeGroupTest {
             // because service may define different settings for different dependencies (for example endpoints, which
             // will be implemented in https://github.com/allegro/envoy-control/issues/6
                 communicationMode = XDS,
-                proxySettings = ProxySettings().with(serviceDependencies = serviceDependencies("*", "a", "b", "c"))
+                proxySettings = ProxySettings().with(serviceDependencies = serviceDependencies("a", "b", "c"),
+                    allServicesDependencies = true
+                )
         ))
     }
 
@@ -87,7 +89,7 @@ class MetadataNodeGroupTest {
         assertThat(group).isEqualTo(
             AllServicesGroup(
                     communicationMode = ADS,
-                    proxySettings = ProxySettings().with(serviceDependencies = serviceDependencies("*"))
+                    proxySettings = ProxySettings().with(allServicesDependencies = true)
             )
         )
     }
@@ -193,7 +195,7 @@ class MetadataNodeGroupTest {
         assertThat(group).isEqualTo(AllServicesGroup(
                 communicationMode = XDS,
                 serviceName = "app1",
-                proxySettings = addedProxySettings.with(serviceDependencies = serviceDependencies("*"))
+                proxySettings = addedProxySettings.with(allServicesDependencies = true)
         ))
     }
 

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataTest.kt
@@ -5,11 +5,13 @@ import com.google.protobuf.util.Durations
 import io.envoyproxy.envoy.config.filter.accesslog.v2.ComparisonFilter
 import io.grpc.Status
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ObjectAssert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import pl.allegro.tech.servicemesh.envoycontrol.snapshot.SnapshotProperties
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.filters.AccessLogFilterFactory
 
 @Suppress("LargeClass")
@@ -26,13 +28,33 @@ class NodeMetadataTest {
 
         @JvmStatic
         fun invalidStatusCodeFilterData() = listOf(
-                Arguments.of("LT:123"),
-                Arguments.of("equal:400"),
-                Arguments.of("eq:24"),
-                Arguments.of("GT:200"),
-                Arguments.of("testeq:400test"),
-                Arguments.of("")
+            Arguments.of("LT:123"),
+            Arguments.of("equal:400"),
+            Arguments.of("eq:24"),
+            Arguments.of("GT:200"),
+            Arguments.of("testeq:400test"),
+            Arguments.of("")
         )
+    }
+
+    private val defaultDependencySettings = DependencySettings(
+        handleInternalRedirect = false,
+        timeoutPolicy = Outgoing.TimeoutPolicy(
+            idleTimeout = Durations.fromMillis(1000),
+            requestTimeout = Durations.fromMillis(3000)
+        )
+    )
+
+    private fun snapshotProperties(
+        allServicesDependenciesIdentifier: String = "*",
+        handleInternalRedirect: Boolean = false,
+        idleTimeout: String = "120s",
+        requestTimeout: String = "120s"
+    ) = SnapshotProperties().apply {
+        outgoingPermissions.allServicesDependencies.identifier = allServicesDependenciesIdentifier
+        egress.handleInternalRedirect = handleInternalRedirect
+        egress.commonHttp.idleTimeout = java.time.Duration.ofNanos(Durations.toNanos(Durations.parse(idleTimeout)))
+        egress.commonHttp.requestTimeout = java.time.Duration.ofNanos(Durations.toNanos(Durations.parse(requestTimeout)))
     }
 
     @Test
@@ -88,10 +110,12 @@ class NodeMetadataTest {
     @Test
     fun `should reject dependency with neither service nor domain field defined`() {
         // given
-        val proto = outgoingDependencyProto()
+        val proto = outgoingDependenciesProto {
+            withInvalid(service = null, domain = null)
+        }
 
         // expects
-        val exception = assertThrows<NodeMetadataValidationException> { proto.toDependency() }
+        val exception = assertThrows<NodeMetadataValidationException> { proto.toOutgoing(snapshotProperties()) }
         assertThat(exception.status.description)
             .isEqualTo("Define either 'service' or 'domain' as an outgoing dependency")
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
@@ -100,10 +124,12 @@ class NodeMetadataTest {
     @Test
     fun `should reject dependency with both service and domain fields defined`() {
         // given
-        val proto = outgoingDependencyProto(service = "service", domain = "http://domain")
+        val proto = outgoingDependenciesProto {
+            withInvalid(service = "service", domain = "http://domain")
+        }
 
         // expects
-        val exception = assertThrows<NodeMetadataValidationException> { proto.toDependency() }
+        val exception = assertThrows<NodeMetadataValidationException> { proto.toOutgoing(snapshotProperties()) }
         assertThat(exception.status.description)
             .isEqualTo("Define either 'service' or 'domain' as an outgoing dependency")
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
@@ -112,57 +138,59 @@ class NodeMetadataTest {
     @Test
     fun `should reject dependency with unsupported protocol in domain field `() {
         // given
-        val proto = outgoingDependencyProto(domain = "ftp://domain")
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "ftp://domain")
+        }
 
         // expects
-        val exception = assertThrows<NodeMetadataValidationException> { proto.toDependency() }
+        val exception = assertThrows<NodeMetadataValidationException> { proto.toOutgoing(snapshotProperties()) }
         assertThat(exception.status.description)
             .isEqualTo("Unsupported protocol for domain dependency for domain ftp://domain")
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
     @Test
-    fun `should check if dependency for service is defined`() {
+    fun `should reject domain dependency with unsupported all services dependencies identifier`() {
         // given
-        val outgoing = Outgoing(listOf(ServiceDependency(
-            service = "service-first",
-            settings = DependencySettings(handleInternalRedirect = true)
-        )))
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "*")
+        }
+        val properties = snapshotProperties(allServicesDependenciesIdentifier = "*")
 
         // expects
-        assertThat(outgoing.containsDependencyForService("service-first")).isTrue()
-        assertThat(outgoing.containsDependencyForService("service-second")).isFalse()
+        val exception = assertThrows<NodeMetadataValidationException> { proto.toOutgoing(properties) }
+        assertThat(exception.status.description)
+            .isEqualTo("Unsupported 'all serviceDependencies identifier' for domain dependency: *")
+        assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
     @Test
     fun `should accept domain dependency`() {
         // given
-        val proto = outgoingDependencyProto(domain = "http://domain")
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "http://domain")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
 
         // expects
-        val dependency = proto.toDependency()
-        assertThat(dependency).isInstanceOf(DomainDependency::class.java)
-        assertThat((dependency as DomainDependency).domain).isEqualTo("http://domain")
-    }
-
-    @Test
-    fun `should accept service dependency`() {
-        // given
-        val proto = outgoingDependencyProto(service = "my-service")
-
-        // expects
-        val dependency = proto.toDependency()
-        assertThat(dependency).isInstanceOf(ServiceDependency::class.java)
-        assertThat((dependency as ServiceDependency).service).isEqualTo("my-service")
+        val dependency = outgoing.domainDependencies.single()
+        assertThat(dependency.domain).isEqualTo("http://domain")
     }
 
     @Test
     fun `should return correct host and default port for domain dependency`() {
         // given
-        val proto = outgoingDependencyProto(domain = "http://domain")
-        val dependency = proto.toDependency() as DomainDependency
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "http://domain")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
 
         // expects
+        val dependency = outgoing.domainDependencies.single()
         assertThat(dependency.getHost()).isEqualTo("domain")
         assertThat(dependency.getPort()).isEqualTo(80)
     }
@@ -170,20 +198,30 @@ class NodeMetadataTest {
     @Test
     fun `should return custom port for domain dependency if it was defined`() {
         // given
-        val proto = outgoingDependencyProto(domain = "http://domain:1234")
-        val dependency = proto.toDependency() as DomainDependency
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "http://domain:1234")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
 
         // expects
+        val dependency = outgoing.domainDependencies.single()
         assertThat(dependency.getPort()).isEqualTo(1234)
     }
 
     @Test
     fun `should return correct names for domain dependency without port specified`() {
         // given
-        val proto = outgoingDependencyProto(domain = "http://domain.pl")
-        val dependency = proto.toDependency() as DomainDependency
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "http://domain.pl")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
 
         // expects
+        val dependency = outgoing.domainDependencies.single()
         assertThat(dependency.getClusterName()).isEqualTo("domain_pl_80")
         assertThat(dependency.getRouteDomain()).isEqualTo("domain.pl")
     }
@@ -191,10 +229,15 @@ class NodeMetadataTest {
     @Test
     fun `should return correct names for domain dependency with port specified`() {
         // given
-        val proto = outgoingDependencyProto(domain = "http://domain.pl:80")
-        val dependency = proto.toDependency() as DomainDependency
+        val proto = outgoingDependenciesProto {
+            withDomain(url = "http://domain.pl:80")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
 
         // expects
+        val dependency = outgoing.domainDependencies.single()
         assertThat(dependency.getClusterName()).isEqualTo("domain_pl_80")
         assertThat(dependency.getRouteDomain()).isEqualTo("domain.pl:80")
     }
@@ -202,10 +245,15 @@ class NodeMetadataTest {
     @Test
     fun `should accept service dependency with redirect policy defined`() {
         // given
-        val proto = outgoingDependencyProto(service = "service-1", handleInternalRedirect = true)
-        val dependency = proto.toDependency() as ServiceDependency
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "service-1", handleInternalRedirect = true)
+        }
 
-        // expects
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties())
+
+        // expect
+        val dependency = outgoing.serviceDependencies.single()
         assertThat(dependency.service).isEqualTo("service-1")
         assertThat(dependency.settings.handleInternalRedirect).isEqualTo(true)
     }
@@ -224,6 +272,167 @@ class NodeMetadataTest {
         assertThat(incoming.healthCheck.clusterName).isEqualTo("local_service_health_check")
         assertThat(incoming.healthCheck.path).isEqualTo("/status/ping")
         assertThat(incoming.healthCheck.hasCustomHealthCheck()).isTrue()
+    }
+
+    @Test
+    fun `should parse allServiceDependency with timeouts configuration`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = "10s", requestTimeout = "10s")
+        }
+
+        // when
+        val outgoing = proto.toOutgoing(snapshotProperties(allServicesDependenciesIdentifier = "*"))
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "10s", requestTimeout = "10s")
+        assertThat(outgoing.serviceDependencies).isEmpty()
+    }
+
+    @Test
+    fun `should parse allServiceDependency and use requestTimeout from properties`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = "10s", requestTimeout = null)
+        }
+        val properties = snapshotProperties(allServicesDependenciesIdentifier = "*", requestTimeout = "5s")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "10s", requestTimeout = "5s")
+        assertThat(outgoing.serviceDependencies).isEmpty()
+    }
+
+    @Test
+    fun `should parse allServiceDependency and use idleTimeout from properties`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = null, requestTimeout = "10s")
+        }
+        val properties = snapshotProperties(allServicesDependenciesIdentifier = "*", idleTimeout = "5s")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "5s", requestTimeout = "10s")
+        assertThat(outgoing.serviceDependencies).isEmpty()
+    }
+
+    @Test
+    fun `should parse allServiceDependency and use timeouts from properties`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = null, requestTimeout = null)
+        }
+        val properties =
+            snapshotProperties(allServicesDependenciesIdentifier = "*", idleTimeout = "5s", requestTimeout = "5s")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "5s", requestTimeout = "5s")
+        assertThat(outgoing.serviceDependencies).isEmpty()
+    }
+
+    @Test
+    fun `should parse service dependencies and for missing config use config defined in allServiceDependency`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = "10s", requestTimeout = "10s")
+            withService(serviceName = "service-name-1", idleTimeout = "5s", requestTimeout = null)
+            withService(serviceName = "service-name-2", idleTimeout = null, requestTimeout = "4s")
+            withService(serviceName = "service-name-3", idleTimeout = null, requestTimeout = null)
+        }
+        val properties = snapshotProperties(allServicesDependenciesIdentifier = "*")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "10s", requestTimeout = "10s")
+
+        outgoing.serviceDependencies.assertServiceDependency("service-name-1")
+            .hasTimeouts(idleTimeout = "5s", requestTimeout = "10s")
+        outgoing.serviceDependencies.assertServiceDependency("service-name-2")
+            .hasTimeouts(idleTimeout = "10s", requestTimeout = "4s")
+        outgoing.serviceDependencies.assertServiceDependency("service-name-3")
+            .hasTimeouts(idleTimeout = "10s", requestTimeout = "10s")
+    }
+
+    @Test
+    fun `should parse service dependencies and for missing configs use config defined in properties when allServiceDependency isn't defined`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "service-name-1", idleTimeout = "5s", requestTimeout = null)
+            withService(serviceName = "service-name-2", idleTimeout = null, requestTimeout = "4s")
+            withService(serviceName = "service-name-3", idleTimeout = null, requestTimeout = null)
+        }
+        val properties = snapshotProperties(idleTimeout = "12s", requestTimeout = "12s")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isFalse()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "12s", requestTimeout = "12s")
+
+        outgoing.serviceDependencies.assertServiceDependency("service-name-1")
+            .hasTimeouts(idleTimeout = "5s", requestTimeout = "12s")
+        outgoing.serviceDependencies.assertServiceDependency("service-name-2")
+            .hasTimeouts(idleTimeout = "12s", requestTimeout = "4s")
+        outgoing.serviceDependencies.assertServiceDependency("service-name-3")
+            .hasTimeouts(idleTimeout = "12s", requestTimeout = "12s")
+    }
+
+    @Test
+    fun `should parse domain dependencies and for missing config use config defined in properties even if allServiceDependency is defined`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withService(serviceName = "*", idleTimeout = "10s", requestTimeout = "10s")
+            withDomain(url = "http://domain-name-1", idleTimeout = "5s", requestTimeout = null)
+            withDomain(url = "http://domain-name-2", idleTimeout = null, requestTimeout = "4s")
+            withDomain(url = "http://domain-name-3", idleTimeout = null, requestTimeout = null)
+        }
+        val properties = snapshotProperties(idleTimeout = "12s", requestTimeout = "12s")
+        // when
+
+        val outgoing = proto.toOutgoing(properties)
+
+        // expects
+        assertThat(outgoing.allServicesDependencies).isTrue()
+        assertThat(outgoing.defaultServiceSettings).hasTimeouts(idleTimeout = "10s", requestTimeout = "10s")
+
+        outgoing.domainDependencies.assertDomainDependency("http://domain-name-1")
+            .hasTimeouts(idleTimeout = "5s", requestTimeout = "12s")
+        outgoing.domainDependencies.assertDomainDependency("http://domain-name-2")
+            .hasTimeouts(idleTimeout = "12s", requestTimeout = "4s")
+        outgoing.domainDependencies.assertDomainDependency("http://domain-name-3")
+            .hasTimeouts(idleTimeout = "12s", requestTimeout = "12s")
+    }
+
+    @Test
+    fun `should throw exception when there are multiple allServiceDependency`() {
+        // given
+        val proto = outgoingDependenciesProto {
+            withServices(serviceDependencies = listOf("*", "*", "a"))
+        }
+
+        // expects
+        val exception = assertThrows<NodeMetadataValidationException> {
+            proto.toOutgoing(snapshotProperties(allServicesDependenciesIdentifier = "*"))
+        }
+        assertThat(exception.status.description)
+            .isEqualTo("Define at most one 'all serviceDependencies identifier' as an service dependency")
+        assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
     @Test
@@ -259,40 +468,6 @@ class NodeMetadataTest {
     }
 
     @Test
-    fun `should accept service dependency with idleTimeout defined`() {
-        // given
-        val proto = outgoingDependencyProto(service = "service-1", idleTimeout = "10s")
-        val dependency = proto.toDependency() as ServiceDependency
-
-        // expects
-        assertThat(dependency.service).isEqualTo("service-1")
-        assertThat(dependency.settings.timeoutPolicy!!.idleTimeout).isEqualTo(Durations.fromSeconds(10L))
-    }
-
-    @Test
-    fun `should accept service dependency with requestTimeout defined`() {
-        // given
-        val proto = outgoingDependencyProto(service = "service-1", requestTimeout = "10s")
-        val dependency = proto.toDependency() as ServiceDependency
-
-        // expects
-        assertThat(dependency.service).isEqualTo("service-1")
-        assertThat(dependency.settings.timeoutPolicy!!.requestTimeout).isEqualTo(Durations.fromSeconds(10L))
-    }
-
-    @Test
-    fun `should accept service dependency with idleTimeout and requestTimeout defined`() {
-        // given
-        val proto = outgoingDependencyProto(service = "service-1", idleTimeout = "10s", requestTimeout = "10s")
-        val dependency = proto.toDependency() as ServiceDependency
-
-        // expects
-        assertThat(dependency.service).isEqualTo("service-1")
-        assertThat(dependency.settings.timeoutPolicy!!.idleTimeout).isEqualTo(Durations.fromSeconds(10L))
-        assertThat(dependency.settings.timeoutPolicy!!.requestTimeout).isEqualTo(Durations.fromSeconds(10L))
-    }
-
-    @Test
     fun `should reject configuration with number timeout format`() {
         // given
         val proto = Value.newBuilder().setNumberValue(10.0).build()
@@ -301,8 +476,10 @@ class NodeMetadataTest {
         val exception = assertThrows<NodeMetadataValidationException> { proto.toDuration() }
 
         // then
-        assertThat(exception.status.description).isEqualTo("Timeout definition has number format" +
-            " but should be in string format and ends with 's'")
+        assertThat(exception.status.description).isEqualTo(
+            "Timeout definition has number format" +
+                " but should be in string format and ends with 's'"
+        )
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
@@ -315,8 +492,10 @@ class NodeMetadataTest {
         val exception = assertThrows<NodeMetadataValidationException> { proto.toDuration() }
 
         // then
-        assertThat(exception.status.description).isEqualTo("Timeout definition has incorrect format: " +
-            "Invalid duration string: 20")
+        assertThat(exception.status.description).isEqualTo(
+            "Timeout definition has incorrect format: " +
+                "Invalid duration string: 20"
+        )
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
     }
 
@@ -353,7 +532,7 @@ class NodeMetadataTest {
 
         // when
         val statusCodeFilterSettings = proto.structValue?.fieldsMap?.get("status_code_filter").toStatusCodeFilter(
-                AccessLogFilterFactory()
+            AccessLogFilterFactory()
         )
 
         // expects
@@ -390,7 +569,29 @@ class NodeMetadataTest {
             )
         }
         assertThat(exception.status.description)
-                .isEqualTo("Invalid access log status code filter. Expected OPERATOR:STATUS_CODE")
+            .isEqualTo("Invalid access log status code filter. Expected OPERATOR:STATUS_CODE")
         assertThat(exception.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+    }
+
+    fun ObjectAssert<DependencySettings>.hasTimeouts(idleTimeout: String, requestTimeout: String): ObjectAssert<DependencySettings> {
+        this.extracting { it.timeoutPolicy }.isEqualTo(Outgoing.TimeoutPolicy(
+            idleTimeout = Durations.parse(idleTimeout),
+            requestTimeout = Durations.parse(requestTimeout)
+        ))
+        return this
+    }
+
+    fun List<ServiceDependency>.assertServiceDependency(name: String): ObjectAssert<DependencySettings> {
+        val list = this.filter { it.service == name }
+        assertThat(list).hasSize(1)
+        val single = list.single().settings
+        return assertThat(single)
+    }
+
+    fun List<DomainDependency>.assertDomainDependency(name: String): ObjectAssert<DependencySettings> {
+        val list = this.filter { it.domain == name }
+        assertThat(list).hasSize(1)
+        val single = list.single().settings
+        return assertThat(single)
     }
 }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
@@ -1,3 +1,4 @@
+@file:Suppress("MatchingDeclarationName")
 package pl.allegro.tech.servicemesh.envoycontrol.groups
 
 import com.google.protobuf.ListValue
@@ -48,19 +49,33 @@ fun node(
         .build()
 }
 
-val addedProxySettings = ProxySettings(Incoming(
-    endpoints = listOf(IncomingEndpoint(
-        path = "/endpoint",
-        clients = setOf(ClientWithSelector("client1"))
-    )),
-    permissionsEnabled = true
-))
-
-fun ProxySettings.with(serviceDependencies: Set<ServiceDependency> = emptySet(), domainDependencies: Set<DomainDependency> = emptySet()) = copy(
-    outgoing = Outgoing(
-        dependencies = serviceDependencies.toList() + domainDependencies.toList()
+val addedProxySettings = ProxySettings(
+    Incoming(
+        endpoints = listOf(
+            IncomingEndpoint(
+                path = "/endpoint",
+                clients = setOf(ClientWithSelector("client1"))
+            )
+        ),
+        permissionsEnabled = true
     )
 )
+
+fun ProxySettings.with(
+    serviceDependencies: Set<ServiceDependency> = emptySet(),
+    domainDependencies: Set<DomainDependency> = emptySet(),
+    allServicesDependencies: Boolean = false,
+    defaultServiceSettings: DependencySettings = DependencySettings()
+): ProxySettings {
+    return copy(
+        outgoing = Outgoing(
+            serviceDependencies = serviceDependencies.toList(),
+            domainDependencies = domainDependencies.toList(),
+            allServicesDependencies = allServicesDependencies,
+            defaultServiceSettings = defaultServiceSettings
+        )
+    )
+}
 
 fun accessLogFilterProto(statusCodeFilter: String? = null): Value = struct {
     when {
@@ -106,12 +121,74 @@ fun proxySettingsProto(
         })
     }
     if (serviceDependencies.isNotEmpty()) {
-        putFields("outgoing", struct {
-            putFields("dependencies", list {
-                serviceDependencies.forEach {
-                    addValues(outgoingDependencyProto(service = it, idleTimeout = idleTimeout, requestTimeout = responseTimeout))
-                }
-            })
+        putFields("outgoing", outgoingDependenciesProto {
+            withServices(serviceDependencies.toList(), idleTimeout, responseTimeout)
+        })
+    }
+}
+
+class OutgoingDependenciesProtoScope {
+    class Dependency(val service: String? = null, val domain: String? = null, val idleTimeout: String? = null, val requestTimeout: String? = null, val handleInternalRedirect: Boolean? = null)
+
+    val dependencies = mutableListOf<Dependency>()
+
+    fun withServices(
+        serviceDependencies: List<String> = emptyList(),
+        idleTimeout: String? = null,
+        responseTimeout: String? = null
+    ) = serviceDependencies.forEach { withService(it, idleTimeout, responseTimeout) }
+
+    fun withService(
+        serviceName: String,
+        idleTimeout: String? = null,
+        requestTimeout: String? = null,
+        handleInternalRedirect: Boolean? = null
+    ) = dependencies.add(
+        Dependency(
+            service = serviceName,
+            idleTimeout = idleTimeout,
+            requestTimeout = requestTimeout,
+            handleInternalRedirect = handleInternalRedirect
+        )
+    )
+
+    fun withDomain(
+        url: String,
+        idleTimeout: String? = null,
+        requestTimeout: String? = null
+    ) = dependencies.add(
+        Dependency(
+            domain = url,
+            idleTimeout = idleTimeout,
+            requestTimeout = requestTimeout
+        )
+    )
+
+    fun withInvalid(service: String? = null, domain: String? = null) = dependencies.add(
+        Dependency(
+            service = service,
+            domain = domain
+        )
+    )
+}
+
+fun outgoingDependenciesProto(
+    closure: OutgoingDependenciesProtoScope.() -> Unit
+): Value {
+    val scope = OutgoingDependenciesProtoScope().apply(closure)
+    return struct {
+        putFields("dependencies", list {
+            scope.dependencies.forEach {
+                addValues(
+                    outgoingDependencyProto(
+                        service = it.service,
+                        domain = it.domain,
+                        idleTimeout = it.idleTimeout,
+                        requestTimeout = it.requestTimeout,
+                        handleInternalRedirect = it.handleInternalRedirect
+                    )
+                )
+            }
         })
     }
 }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
@@ -5,6 +5,7 @@ import com.google.protobuf.ListValue
 import com.google.protobuf.NullValue
 import com.google.protobuf.Struct
 import com.google.protobuf.Value
+import com.google.protobuf.util.Durations
 import io.envoyproxy.envoy.api.v2.core.Node
 
 fun node(
@@ -65,7 +66,10 @@ fun ProxySettings.with(
     serviceDependencies: Set<ServiceDependency> = emptySet(),
     domainDependencies: Set<DomainDependency> = emptySet(),
     allServicesDependencies: Boolean = false,
-    defaultServiceSettings: DependencySettings = DependencySettings()
+    defaultServiceSettings: DependencySettings = DependencySettings(timeoutPolicy = Outgoing.TimeoutPolicy(
+        Durations.fromSeconds(120),
+        Durations.fromSeconds(120)
+    ))
 ): ProxySettings {
     return copy(
         outgoing = Outgoing(

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
+@Suppress("LargeClass")
 class SnapshotUpdaterTest {
 
     companion object {
@@ -86,6 +87,43 @@ class SnapshotUpdaterTest {
         ),
         Locality.LOCAL, "cluster"
     ).toMultiClusterState()
+
+    @Test
+    fun `should generate allServicesGroup snapshots with timeouts from proxySettings`() {
+        val cache = MockCache()
+
+        val allServicesGroup = AllServicesGroup(communicationMode = XDS, proxySettings = ProxySettings(outgoing = Outgoing(
+            serviceDependencies = listOf(ServiceDependency(
+                service = "existingService1",
+                settings = DependencySettings(timeoutPolicy = Outgoing.TimeoutPolicy(
+                    idleTimeout = Durations.parse("10s"),
+                    requestTimeout = Durations.parse("9s")
+                ))
+            )),
+            defaultServiceSettings = DependencySettings(timeoutPolicy = Outgoing.TimeoutPolicy(
+                idleTimeout = Durations.parse("8s"),
+                requestTimeout = Durations.parse("7s")
+            )),
+            allServicesDependencies = true
+        )))
+
+        cache.setSnapshot(allServicesGroup, uninitializedSnapshot)
+
+        val updater = snapshotUpdater(
+            cache = cache,
+            properties = SnapshotProperties().apply {
+                incomingPermissions.enabled = true
+            },
+            groups = listOf(allServicesGroup)
+        )
+
+        updater.startWithServices("existingService1", "existingService2")
+
+        hasSnapshot(cache, allServicesGroup)
+            .hasOnlyClustersFor("existingService1", "existingService2")
+            .hasVirtualHostConfig(name = "existingService1", idleTimeout = "10s", requestTimeout = "9s")
+            .hasVirtualHostConfig(name = "existingService2", idleTimeout = "8s", requestTimeout = "7s")
+    }
 
     @Test
     fun `should generate group snapshots`() {
@@ -480,6 +518,16 @@ class SnapshotUpdaterTest {
 
     private fun Snapshot.withoutClusters() {
         assertThat(this.clusters().resources().keys).isEmpty()
+    }
+
+    private fun Snapshot.hasVirtualHostConfig(name: String, idleTimeout: String, requestTimeout: String): Snapshot {
+        val routeAction = this.routes()
+            .resources()["default_routes"]!!.virtualHostsList.singleOrNull { it.name == name }?.routesList?.map { it.route }
+            ?.singleOrNull()
+        assertThat(routeAction).overridingErrorMessage("Expecting virtualHost for $name").isNotNull
+        assertThat(routeAction?.timeout).isEqualTo(Durations.parse(requestTimeout))
+        assertThat(routeAction?.idleTimeout).isEqualTo(Durations.parse(idleTimeout))
+        return this
     }
 
     private fun groupOf(

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotsVersionsTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotsVersionsTest.kt
@@ -157,7 +157,7 @@ internal class SnapshotsVersionsTest {
                             )
                         )
                     ),
-                    outgoing = Outgoing(listOf())
+                    outgoing = Outgoing()
                 )
         )
     }


### PR DESCRIPTION
You can specify timeouts for wildcard dependency and override it for specified services
```
metadata:
  proxy_settings:
    outgoing:
      dependencies:
        - service: "*"
          timeoutPolicy:
            idleTimeout: 400
            requestTimeout: 800
        - service: "slow-service-A"
            timeoutPolicy:
              idleTimeout: 800
              requestTimeout: 1500
        - service: "slow-service-B"
            timeoutPolicy:
              idleTimeout: 800
              requestTimeout: 1500  
```


