### PR TITLE
Deduplicate dependencies

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
@@ -289,11 +289,24 @@ data class Incoming(
 }
 
 data class Outgoing(
-    val serviceDependencies: List<ServiceDependency> = emptyList(),
-    val domainDependencies: List<DomainDependency> = emptyList(),
+    private val serviceDependencies: List<ServiceDependency> = emptyList(),
+    private val domainDependencies: List<DomainDependency> = emptyList(),
     val allServicesDependencies: Boolean = false,
     val defaultServiceSettings: DependencySettings = DependencySettings()
 ) {
+
+    // not declared in primary constructor to exclude from equals(), copy(), etc.
+    private val deduplicatedDomainDependencies: List<DomainDependency> = domainDependencies
+        .map { it.domain to it }
+        .toMap().values.toList()
+
+    private val deduplicatedServiceDependencies: List<ServiceDependency> = serviceDependencies
+        .map { it.service to it }
+        .toMap().values.toList()
+
+    fun getDomainDependencies(): List<DomainDependency> = deduplicatedDomainDependencies
+    fun getServiceDependencies(): List<ServiceDependency> = deduplicatedServiceDependencies
+
     data class TimeoutPolicy(
         val idleTimeout: Duration? = null,
         val requestTimeout: Duration? = null

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
@@ -155,7 +155,7 @@ class EnvoySnapshotFactory(
     }
 
     private fun getDomainRouteSpecifications(group: Group): List<RouteSpecification> {
-        return group.proxySettings.outgoing.domainDependencies.map {
+        return group.proxySettings.outgoing.getDomainDependencies().map {
             RouteSpecification(
                 clusterName = it.getClusterName(),
                 routeDomain = it.getRouteDomain(),
@@ -168,7 +168,7 @@ class EnvoySnapshotFactory(
         group: Group,
         globalSnapshot: GlobalSnapshot
     ): Collection<RouteSpecification> {
-        val definedServicesRoutes = group.proxySettings.outgoing.serviceDependencies.map {
+        val definedServicesRoutes = group.proxySettings.outgoing.getServiceDependencies().map {
             RouteSpecification(
                 clusterName = it.service,
                 routeDomain = it.service,
@@ -180,7 +180,7 @@ class EnvoySnapshotFactory(
                 definedServicesRoutes
             }
             is AllServicesGroup -> {
-                val servicesNames = group.proxySettings.outgoing.serviceDependencies.map { it.service }.toSet()
+                val servicesNames = group.proxySettings.outgoing.getServiceDependencies().map { it.service }.toSet()
                 val allServicesRoutes = globalSnapshot.allServicesNames.subtract(servicesNames).map {
                     RouteSpecification(
                         clusterName = it,

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
@@ -99,7 +99,7 @@ class EnvoyClustersFactory(
         }
 
         return when (group) {
-            is ServicesGroup -> group.proxySettings.outgoing.serviceDependencies.mapNotNull {
+            is ServicesGroup -> group.proxySettings.outgoing.getServiceDependencies().mapNotNull {
                 clusters.get(it.service)
             }
             is AllServicesGroup -> globalSnapshot.allServicesNames.mapNotNull {
@@ -145,7 +145,7 @@ class EnvoyClustersFactory(
     }
 
     private fun getStrictDnsClustersForGroup(group: Group): List<Cluster> {
-        return group.proxySettings.outgoing.domainDependencies.map {
+        return group.proxySettings.outgoing.getDomainDependencies().map {
             strictDnsCluster(it.getClusterName(), it.getHost(), it.getPort(), it.useSsl())
         }
     }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataTest.kt
@@ -273,8 +273,8 @@ class NodeMetadataTest {
     fun `should deduplicate services dependencies based on serviceName`() {
         // given
         val proto = outgoingDependenciesProto {
-            withService(serviceName = "service-1", requestTimeout = "8s",idleTimeout = "8s")
-            withService(serviceName = "service-1", requestTimeout = "10s",idleTimeout = "10s")
+            withService(serviceName = "service-1", requestTimeout = "8s", idleTimeout = "8s")
+            withService(serviceName = "service-1", requestTimeout = "10s", idleTimeout = "10s")
             withService(serviceName = "service-2")
         }
 


### PR DESCRIPTION
PR https://github.com/allegro/envoy-control/pull/165 changed how EC handles duplicates in dependencies list. EC throws exception when this case occurs. This PR reverts to previous behaviour: Dependencies for same serviceName/domainUrl will be deduplicated and last one remain.

```yaml
metadata:
  proxy_settings:
    outgoing:
      dependencies:
        - service: "service-A"
            timeoutPolicy:
              idleTimeout: "10s"
              requestTimeout: "8s"
        - service: "service-A"
```
