### PR TITLE
Better dependency cache for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: ./gradlew dependencies
+      - run: ./gradlew envoy-control-runner:dependencies envoy-control-test:dependencies envoy-control-source-consul:dependencies
 
       - save_cache:
           paths:


### PR DESCRIPTION
Running just the top level dependencies task, doesn't fetch
most of the relevant dependencies for the project.