### PR TITLE
makes SnapshotUpdaterBadConfigTest pass for the right reasons

### DIFF
--- a/envoy-control-tests/src/main/resources/envoy/bad_config.yaml
+++ b/envoy-control-tests/src/main/resources/envoy/bad_config.yaml
@@ -29,20 +29,20 @@ node:
 static_resources:
   clusters:
   - connect_timeout: 1s
-  load_assignment:
-    cluster_name: envoy-control-xds
-    endpoints:
-      - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: HOST_IP
-                  port_value: HOST_PORT
-          - endpoint:
-              address:
-                socket_address:
-                  address: HOST_IP
-                  port_value: HOST2_PORT
+    load_assignment:
+      cluster_name: envoy-control-xds
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: HOST_IP
+                    port_value: HOST_PORT
+            - endpoint:
+                address:
+                  socket_address:
+                    address: HOST_IP
+                    port_value: HOST2_PORT
     http2_protocol_options: {}
     name: envoy-control-xds
   - name: local_service


### PR DESCRIPTION
`SnapshotUpdaterBadConfigTest` is supposed verify that EC is resilient to Envoy sending invalid proxy settings. Due to wrong YAML indentation the badly configured Envoy did not cause any invalid proxy settings to reach EC, instead failing to start at all.