### PR TITLE
Add service name and destination header to response

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
@@ -175,11 +175,7 @@ class MetadataNodeGroup(
     }
 
     private fun serviceName(metadata: NodeMetadata): String {
-        return when (properties.incomingPermissions.enabled) {
-            true -> metadata.serviceName.orEmpty()
-            // TODO: https://github.com/allegro/envoy-control/issues/91
-            false -> ""
-        }
+        return metadata.serviceName.orEmpty()
     }
 
     private fun proxySettings(metadata: NodeMetadata): ProxySettings {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataValidator.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadataValidator.kt
@@ -38,6 +38,10 @@ class ConfigurationModeNotSupportedException(serviceName: String?, mode: String)
     "Blocked service $serviceName from receiving updates. $mode is not supported by server."
 )
 
+class ServiceNameNotProvidedException : NodeMetadataValidationException(
+    "Service name has not been provided."
+)
+
 class NodeMetadataValidator(
     val properties: SnapshotProperties
 ) : DiscoveryServerCallbacks {
@@ -88,9 +92,18 @@ class NodeMetadataValidator(
     }
 
     private fun validateMetadata(metadata: NodeMetadata) {
+        validateServiceName(metadata)
         validateDependencies(metadata)
         validateIncomingEndpoints(metadata)
         validateConfigurationMode(metadata)
+    }
+
+    private fun validateServiceName(metadata: NodeMetadata) {
+        if (properties.requireServiceName) {
+            if (metadata.serviceName.isNullOrEmpty()) {
+                throw ServiceNameNotProvidedException()
+            }
+        }
     }
 
     private fun validateDependencies(metadata: NodeMetadata) {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/EnvoySnapshotFactory.kt
@@ -246,7 +246,7 @@ class EnvoySnapshotFactory(
                 group.listenersConfig?.addUpstreamExternalAddressHeader ?: false,
                 group.version
             ),
-            ingressRoutesFactory.createSecuredIngressRouteConfig(group.proxySettings)
+            ingressRoutesFactory.createSecuredIngressRouteConfig(group.serviceName, group.proxySettings)
         )
 
         val listeners = if (properties.dynamicListeners.enabled) {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
@@ -31,6 +31,7 @@ class SnapshotProperties {
     var metrics: MetricsProperties = MetricsProperties()
     var dynamicForwardProxy = DynamicForwardProxyProperties()
     var jwt = JwtFilterProperties()
+    var requireServiceName = false
 }
 
 class MetricsProperties {
@@ -249,6 +250,7 @@ class EgressProperties {
 
 class IngressProperties {
     var headersToRemove = mutableListOf<String>()
+    var addServiceNameHeaderToResponse = false
 }
 
 class CommonHttpProperties {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
@@ -251,9 +251,9 @@ class EgressProperties {
 class IngressProperties {
     var headersToRemove = mutableListOf<String>()
     var addServiceNameHeaderToResponse = false
-    var addRequestedServiceNameHeaderToResponse = false
+    var addRequestedAuthorityHeaderToResponse = false
     var serviceNameHeader = "x-service-name"
-    var requestedServiceNameHeader = "x-requested-service-name"
+    var requestedAuthorityHeader = "x-requested-authority"
 }
 
 class CommonHttpProperties {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotProperties.kt
@@ -251,6 +251,9 @@ class EgressProperties {
 class IngressProperties {
     var headersToRemove = mutableListOf<String>()
     var addServiceNameHeaderToResponse = false
+    var addRequestedServiceNameHeaderToResponse = false
+    var serviceNameHeader = "x-service-name"
+    var requestedServiceNameHeader = "x-requested-service-name"
 }
 
 class CommonHttpProperties {

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
@@ -1,5 +1,6 @@
 package pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes
 
+import com.google.protobuf.BoolValue
 import com.google.protobuf.Duration
 import com.google.protobuf.UInt32Value
 import com.google.protobuf.util.Durations
@@ -179,16 +180,16 @@ class EnvoyIngressRoutesFactory(
                     HeaderValue.newBuilder()
                         .setKey(properties.ingress.serviceNameHeader)
                         .setValue(serviceName).build()
-                )
+                ).setAppend(BoolValue.of(false))
             )
         }
-        if (properties.ingress.addRequestedServiceNameHeaderToResponse) {
+        if (properties.ingress.addRequestedAuthorityHeaderToResponse) {
             builder.addResponseHeadersToAdd(
                 HeaderValueOption.newBuilder().setHeader(
                     HeaderValue.newBuilder()
-                        .setKey(properties.ingress.requestedServiceNameHeader)
+                        .setKey(properties.ingress.requestedAuthorityHeader)
                         .setValue("%REQ(:authority)%").build()
-                )
+                ).setAppend(BoolValue.of(false))
             )
         }
 

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
@@ -177,8 +177,17 @@ class EnvoyIngressRoutesFactory(
             builder.addResponseHeadersToAdd(
                 HeaderValueOption.newBuilder().setHeader(
                     HeaderValue.newBuilder()
-                        .setKey(properties.incomingPermissions.serviceNameHeader)
+                        .setKey(properties.ingress.serviceNameHeader)
                         .setValue(serviceName).build()
+                )
+            )
+        }
+        if (properties.ingress.addRequestedServiceNameHeaderToResponse) {
+            builder.addResponseHeadersToAdd(
+                HeaderValueOption.newBuilder().setHeader(
+                    HeaderValue.newBuilder()
+                        .setKey(properties.ingress.requestedServiceNameHeader)
+                        .setValue("%REQ(:authority)%").build()
                 )
             )
         }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactory.kt
@@ -3,6 +3,8 @@ package pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.routes
 import com.google.protobuf.Duration
 import com.google.protobuf.UInt32Value
 import com.google.protobuf.util.Durations
+import io.envoyproxy.envoy.config.core.v3.HeaderValue
+import io.envoyproxy.envoy.config.core.v3.HeaderValueOption
 import io.envoyproxy.envoy.config.route.v3.HeaderMatcher
 import io.envoyproxy.envoy.config.route.v3.RetryPolicy
 import io.envoyproxy.envoy.config.route.v3.Route
@@ -143,7 +145,7 @@ class EnvoyIngressRoutesFactory(
         routeAction: RouteAction.Builder
     ) = routeAction.clone().setRetryPolicy(retryPolicy)
 
-    fun createSecuredIngressRouteConfig(proxySettings: ProxySettings): RouteConfiguration {
+    fun createSecuredIngressRouteConfig(serviceName: String, proxySettings: ProxySettings): RouteConfiguration {
         val virtualClusters = when (statusRouteVirtualClusterEnabled()) {
             true -> {
                 statusClusters + endpoints
@@ -168,10 +170,17 @@ class EnvoyIngressRoutesFactory(
         val builder = RouteConfiguration.newBuilder()
             .setName("ingress_secured_routes")
 
-        when {
-            properties.ingress.headersToRemove.isNotEmpty() -> {
-                builder.addAllRequestHeadersToRemove(properties.ingress.headersToRemove)
-            }
+        if (properties.ingress.headersToRemove.isNotEmpty()) {
+            builder.addAllRequestHeadersToRemove(properties.ingress.headersToRemove)
+        }
+        if (properties.ingress.addServiceNameHeaderToResponse) {
+            builder.addResponseHeadersToAdd(
+                HeaderValueOption.newBuilder().setHeader(
+                    HeaderValue.newBuilder()
+                        .setKey(properties.incomingPermissions.serviceNameHeader)
+                        .setValue(serviceName).build()
+                )
+            )
         }
 
         return builder

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
@@ -152,7 +152,8 @@ class MetadataNodeGroupTest {
         assertThat(group).isEqualTo(
             ServicesGroup(
                 proxySettings = ProxySettings().with(serviceDependencies = serviceDependencies("a", "b", "c")),
-                communicationMode = XDS
+                communicationMode = XDS,
+                serviceName = "app1"
             )
         )
     }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
@@ -17,6 +17,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.groups.hasNoRetryPolicy
 import pl.allegro.tech.servicemesh.envoycontrol.groups.hasOneDomain
 import pl.allegro.tech.servicemesh.envoycontrol.groups.hasOnlyRoutesInOrder
 import pl.allegro.tech.servicemesh.envoycontrol.groups.hasRequestHeadersToRemove
+import pl.allegro.tech.servicemesh.envoycontrol.groups.hasResponseHeaderToAdd
 import pl.allegro.tech.servicemesh.envoycontrol.groups.hasSingleVirtualHostThat
 import pl.allegro.tech.servicemesh.envoycontrol.groups.hasStatusVirtualClusters
 import pl.allegro.tech.servicemesh.envoycontrol.groups.matchingOnAnyMethod
@@ -97,7 +98,7 @@ internal class EnvoyIngressRoutesFactoryTest {
         )
 
         // when
-        val routeConfig = routesFactory.createSecuredIngressRouteConfig(proxySettingsOneEndpoint)
+        val routeConfig = routesFactory.createSecuredIngressRouteConfig("service_1", proxySettingsOneEndpoint)
 
         // then
         routeConfig
@@ -127,10 +128,11 @@ internal class EnvoyIngressRoutesFactoryTest {
     }
 
     @Test
-    fun `should create route config with headers to remove`() {
+    fun `should create route config with headers to remove and add`() {
         // given
         val routesFactory = EnvoyIngressRoutesFactory(SnapshotProperties().apply {
             ingress.headersToRemove = mutableListOf("x-via-vip", "x-special-case-header")
+            ingress.addServiceNameHeaderToResponse = true
         })
         val proxySettingsOneEndpoint = ProxySettings(
                 incoming = Incoming(
@@ -143,9 +145,11 @@ internal class EnvoyIngressRoutesFactoryTest {
         )
 
         // when
-        val routeConfig = routesFactory.createSecuredIngressRouteConfig(proxySettingsOneEndpoint)
+        val routeConfig = routesFactory.createSecuredIngressRouteConfig("service_1", proxySettingsOneEndpoint)
 
         // then
-        routeConfig.hasRequestHeadersToRemove(listOf("x-via-vip", "x-special-case-header"))
+        routeConfig
+            .hasRequestHeadersToRemove(listOf("x-via-vip", "x-special-case-header"))
+            .hasResponseHeaderToAdd("x-service-name", "service_1")
     }
 }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
@@ -133,6 +133,7 @@ internal class EnvoyIngressRoutesFactoryTest {
         val routesFactory = EnvoyIngressRoutesFactory(SnapshotProperties().apply {
             ingress.headersToRemove = mutableListOf("x-via-vip", "x-special-case-header")
             ingress.addServiceNameHeaderToResponse = true
+            ingress.addRequestedAuthorityHeaderToResponse = true
         })
         val proxySettingsOneEndpoint = ProxySettings(
                 incoming = Incoming(
@@ -151,5 +152,6 @@ internal class EnvoyIngressRoutesFactoryTest {
         routeConfig
             .hasRequestHeadersToRemove(listOf("x-via-vip", "x-special-case-header"))
             .hasResponseHeaderToAdd("x-service-name", "service_1")
+            .hasResponseHeaderToAdd("x-requested-authority", "%REQ(:authority)%")
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
@@ -1,0 +1,53 @@
+package pl.allegro.tech.servicemesh.envoycontrol
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.service.EchoServiceExtension
+
+class LocalServiceTest {
+
+    companion object {
+        private const val prefix = "envoy-control.envoy.snapshot"
+
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(
+            consul, mapOf(
+                "$prefix.ingress.add-service-name-header-to-response" to true
+            )
+        )
+
+        @JvmField
+        @RegisterExtension
+        val service = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val envoy = EnvoyExtension(envoyControl, service)
+    }
+
+    @Test
+    fun `should add header with service name to response`() {
+        // given
+        consul.server.operations.registerService(service, name = "service-1")
+
+        // when
+        untilAsserted {
+            // when
+            val response = envoy.ingressOperations.callLocalService("/")
+
+            assertThat(response).isOk()
+            assertThat(response.header("x-service-name")).isEqualTo("echo2")
+        }
+    }
+}

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
@@ -1,5 +1,6 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
+import okhttp3.Headers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -23,7 +24,8 @@ class LocalServiceTest {
         @RegisterExtension
         val envoyControl = EnvoyControlExtension(
             consul, mapOf(
-                "$prefix.ingress.add-service-name-header-to-response" to true
+                "$prefix.ingress.add-service-name-header-to-response" to true,
+                "$prefix.ingress.add-requested-service-name-header-to-response" to true
             )
         )
 
@@ -44,10 +46,11 @@ class LocalServiceTest {
         // when
         untilAsserted {
             // when
-            val response = envoy.ingressOperations.callLocalService("/")
+            val response = envoy.ingressOperations.callLocalService("/", headers = Headers.of("host", "test-service"))
 
             assertThat(response).isOk()
             assertThat(response.header("x-service-name")).isEqualTo("echo2")
+            assertThat(response.header("x-requested-service-name")).isEqualTo("test-service")
         }
     }
 }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/LocalServiceTest.kt
@@ -25,7 +25,7 @@ class LocalServiceTest {
         val envoyControl = EnvoyControlExtension(
             consul, mapOf(
                 "$prefix.ingress.add-service-name-header-to-response" to true,
-                "$prefix.ingress.add-requested-service-name-header-to-response" to true
+                "$prefix.ingress.add-requested-authority-header-to-response" to true
             )
         )
 
@@ -50,7 +50,7 @@ class LocalServiceTest {
 
             assertThat(response).isOk()
             assertThat(response.header("x-service-name")).isEqualTo("echo2")
-            assertThat(response.header("x-requested-service-name")).isEqualTo("test-service")
+            assertThat(response.header("x-requested-authority")).isEqualTo("test-service")
         }
     }
 }

--- a/envoy-control-tests/src/main/resources/envoy/config_xds.yaml
+++ b/envoy-control-tests/src/main/resources/envoy/config_xds.yaml
@@ -33,6 +33,7 @@ node:
     access_log_enabled: false
     add_upstream_external_address_header: true
     resources_dir: "/etc/envoy/extra"
+    service_name: "echo2"
     proxy_settings:
       incoming:
         endpoints:


### PR DESCRIPTION
Require service-name in request fixes: https://github.com/allegro/envoy-control/issues/91