### PR TITLE
Rbac allow original destination

### DIFF
--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
@@ -176,8 +176,8 @@ class EnvoyClustersFactory(
             is AllServicesGroup -> {
                 globalSnapshot.allServicesNames.mapNotNull {
                     val dependency = serviceDependencies[it]
-                    if (dependency != null && dependency.settings.timeoutPolicy.idleTimeout != null) {
-                        createClusterForGroup(serviceDependencies[it]!!.settings, clusters[it])
+                    if (dependency != null && dependency.settings.timeoutPolicy.connectionIdleTimeout != null) {
+                        createClusterForGroup(dependency.settings, clusters[it])
                     } else {
                         createClusterForGroup(group.proxySettings.outgoing.defaultServiceSettings, clusters[it])
                     }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/RBACFilterFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/RBACFilterFactory.kt
@@ -279,7 +279,6 @@ class RBACFilterFactory(
         return clients.toSortedSet()
     }
 
-
     private fun mapClientWithSelectorToPrincipals(
         clientWithSelector: ClientWithSelector,
         snapshot: GlobalSnapshot
@@ -468,9 +467,10 @@ class RBACFilterFactory(
     }
 
     private fun originalDestinationPrincipals(client: String) = Principal.newBuilder()
-        .setAndIds(Principal.Set.newBuilder()
-            .addIds(exactMatchPrincipal(":authority","envoy-original-destination"))
-            .addIds(exactMatchPrincipal(incomingPermissionsProperties.serviceNameHeader, client))
+        .setAndIds(
+            Principal.Set.newBuilder()
+                .addIds(exactMatchPrincipal(":authority", "envoy-original-destination"))
+                .addIds(exactMatchPrincipal(incomingPermissionsProperties.serviceNameHeader, client))
         ).build()
 
     private fun exactMatchPrincipal(headerName: String, match: String) = Principal.newBuilder()

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryJwtTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryJwtTest.kt
@@ -144,12 +144,12 @@ internal class RBACFilterFactoryJwtTest : RBACFilterFactoryTestUtils {
         )
         val expectedRbacBuilder = getRBACFilterWithShadowRules(
             expectedPoliciesForOAuth(
-                authenticatedPrincipal("client1"),
+                originalAndAuthenticatedPrincipal("client1"),
                 "ClientWithSelector(name=client1, selector=null)",
                 "OAuth(provider=oauth-provider, verification=OFFLINE, policy=ALLOW_MISSING_OR_FAILED)"
             ),
             expectedPoliciesForOAuth(
-                authenticatedPrincipal("client1"),
+                originalAndAuthenticatedPrincipal("client1"),
                 "ClientWithSelector(name=client1, selector=null)",
                 "OAuth(provider=oauth-provider, verification=OFFLINE, policy=ALLOW_MISSING_OR_FAILED)"
             )
@@ -339,13 +339,7 @@ internal class RBACFilterFactoryJwtTest : RBACFilterFactoryTestUtils {
                   }
                 }]
               }
-            }, {
-              "authenticated": {
-                "principalName": {
-                  "exact": "spiffe://$client"
-                }
-              }
-            }]
+            }, ${originalAndAuthenticatedPrincipal(client)}]
           }
         }"""
         OAuth.Policy.ALLOW_MISSING -> """{
@@ -394,16 +388,10 @@ internal class RBACFilterFactoryJwtTest : RBACFilterFactoryTestUtils {
                   }
                 }]
               }
-            }, {
-              "authenticated": {
-                "principalName": {
-                  "exact": "spiffe://$client"
-                }
-              }
-            }]
+            }, ${originalAndAuthenticatedPrincipal(client)}]
           }
         }"""
-        OAuth.Policy.ALLOW_MISSING_OR_FAILED -> authenticatedPrincipal("client1")
+        OAuth.Policy.ALLOW_MISSING_OR_FAILED -> originalAndAuthenticatedPrincipal("client1")
     }
 
     private fun oAuthPrincipalsNoClients(policy: OAuth.Policy): String {

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryTest.kt
@@ -1,4 +1,4 @@
-package pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.filters
+package pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.filters.rbac
 
 import io.envoyproxy.controlplane.cache.SnapshotResources
 import io.envoyproxy.envoy.config.core.v3.Address
@@ -20,7 +20,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.snapshot.IncomingPermissionsProp
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.SelectorMatching
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.SourceIpAuthenticationProperties
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.StatusRouteProperties
-import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.filters.rbac.RBACFilterFactoryTestUtils
+import pl.allegro.tech.servicemesh.envoycontrol.snapshot.resource.listeners.filters.RBACFilterFactory
 
 @Suppress("LargeClass") // TODO: https://github.com/allegro/envoy-control/issues/121
 internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
@@ -743,7 +743,7 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal("client1")}
+                ${originalAndAuthenticatedPrincipal("client1")}
               ]
             },
             "IncomingEndpoint(path=/example2, pathMatchingType=PATH, methods=[POST], clients=[ClientWithSelector(name=client2, selector=null)], unlistedClientsPolicy=BLOCKANDLOG, oauth=null)": {
@@ -763,7 +763,7 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal("client2")}
+                ${originalAndAuthenticatedPrincipal("client2")}
               ]
             }
           }
@@ -906,7 +906,7 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                 }
               ], "principals": [
                 { "orIds": { "ids": [${principalSourceIp("127.0.0.1")}] } },
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             }
           }
@@ -934,8 +934,8 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal(("client1"))},
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client1"))},
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             }
           }
@@ -964,9 +964,9 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal(("client1"))},
-                ${authenticatedPrincipal(("client1-duplicated"))},
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client1"))},
+                ${originalAndAuthenticatedPrincipal(("client1-duplicated"))},
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             }
           }
@@ -994,8 +994,8 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal(("client1"))},
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client1"))},
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             },
             "${policyNames[1]}": {
@@ -1016,8 +1016,8 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                   }
                 }
               ], "principals": [
-                ${authenticatedPrincipal(("client1"))},
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client1"))},
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             }
           }
@@ -1248,8 +1248,8 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
                       }
                 }
               ], "principals": [
-                ${authenticatedPrincipal(("client1"))},
-                ${authenticatedPrincipal(("client2"))}
+                ${originalAndAuthenticatedPrincipal(("client1"))},
+                ${originalAndAuthenticatedPrincipal(("client2"))}
               ]
             },
             "ALLOW_UNLISTED_POLICY": {
@@ -1309,10 +1309,10 @@ internal class RBACFilterFactoryTest : RBACFilterFactoryTestUtils {
     """
 
     private val expectedRulesForAllowedClient = expectedPoliciesForAllowedClient(
-        "${authenticatedPrincipal("client1")}, ${authenticatedPrincipal("allowed-client")}"
+        "${originalAndAuthenticatedPrincipal("client1")}, ${originalAndAuthenticatedPrincipal("allowed-client")}"
     )
 
     private val expectedShadowRulesForAllowedClient = expectedPoliciesForAllowedClient(
-        authenticatedPrincipal("client1")
+        originalAndAuthenticatedPrincipal("client1")
     )
 }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryTestUtils.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/rbac/RBACFilterFactoryTestUtils.kt
@@ -59,12 +59,40 @@ interface RBACFilterFactoryTestUtils {
                 }"""
     }
 
+    fun originalAndAuthenticatedPrincipal(value: String): String {
+        return """{
+                "or_ids": {
+                    "ids":[${authenticatedPrincipal(value)}, ${originalDestinationPrincipal(value)}]
+            }
+        }
+        """
+    }
     fun authenticatedPrincipal(value: String): String {
         return """{
                     "authenticated": {
                       "principal_name": {
                         "exact": "spiffe://$value"
                       }
+                    }
+                }"""
+    }
+    fun originalDestinationPrincipal(value: String): String {
+        return """{
+                    "and_ids": {
+                        "ids": [
+                            {
+                                "header": {
+                                    "name": ":authority",
+                                    "exact_match": "envoy-original-destination"
+                                }
+                            },
+                            {
+                                "header": {
+                                    "name": "x-service-name",
+                                    "exact_match": "$value"
+                                }
+                            }
+                        ]
                     }
                 }"""
     }
@@ -91,7 +119,7 @@ interface RBACFilterFactoryTestUtils {
 
     fun getRBACFilterWithShadowRules(rules: String, shadowRules: String): HttpFilter {
         val rbacFilter = RBAC.newBuilder()
-        JsonFormat.parser().merge(wrapInFilter(rules), rbacFilter)
+         JsonFormat.parser().merge(wrapInFilter(rules), rbacFilter)
         JsonFormat.parser().merge(wrapInFilterShadow(shadowRules), rbacFilter)
         return HttpFilter.newBuilder()
             .setName("envoy.filters.http.rbac")

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/IngressOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/IngressOperations.kt
@@ -2,12 +2,14 @@ package pl.allegro.tech.servicemesh.envoycontrol.config.envoy
 
 import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
+import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
 import pl.allegro.tech.servicemesh.envoycontrol.config.ClientsFactory
 import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.HttpResponseCloser.addToCloseableResponses
+import pl.allegro.tech.servicemesh.envoycontrol.config.service.EchoServiceExtension
 
 class IngressOperations(val envoy: EnvoyContainer) {
 
@@ -29,6 +31,14 @@ class IngressOperations(val envoy: EnvoyContainer) {
                             .build()
             )
                     .execute().addToCloseableResponses()
+
+    fun callServiceWithOriginalDst(service: EchoServiceExtension, path: String = "", serviceName: String,  useTls: Boolean = false) =
+        callLocalServiceInsecure(
+            path,
+            mapOf("x-envoy-original-dst-host" to service.container().address(),
+                "host" to "envoy-original-destination",  "x-service-name" to serviceName).toHeaders(),
+            useTls
+        )
 
     private fun callLocalService(
         endpoint: String,

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/IngressOperations.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/IngressOperations.kt
@@ -32,11 +32,11 @@ class IngressOperations(val envoy: EnvoyContainer) {
             )
                     .execute().addToCloseableResponses()
 
-    fun callServiceWithOriginalDst(service: EchoServiceExtension, path: String = "", serviceName: String,  useTls: Boolean = false) =
+    fun callServiceWithOriginalDst(service: EchoServiceExtension, path: String = "", serviceName: String, useTls: Boolean = false) =
         callLocalServiceInsecure(
             path,
             mapOf("x-envoy-original-dst-host" to service.container().address(),
-                "host" to "envoy-original-destination",  "x-service-name" to serviceName).toHeaders(),
+                "host" to "envoy-original-destination", "x-service-name" to serviceName).toHeaders(),
             useTls
         )
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
@@ -53,9 +53,9 @@ class IncomingPermissionsOriginalDestinationTest {
         @RegisterExtension
         val envoyControl = EnvoyControlExtension(
             consul, mapOf(
-                "${prefix}.incoming-permissions.enabled" to true,
-                "${prefix}.outgoing-permissions.enabled" to true,
-                "${prefix}.routes.status.create-virtual-cluster" to true
+                "$prefix.incoming-permissions.enabled" to true,
+                "$prefix.outgoing-permissions.enabled" to true,
+                "$prefix.routes.status.create-virtual-cluster" to true
             )
         )
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
@@ -1,6 +1,6 @@
 package pl.allegro.tech.servicemesh.envoycontrol.permissions
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -95,11 +95,11 @@ class IncomingPermissionsOriginalDestinationTest {
 
     private fun waitForEnvoysInitialized() {
         untilAsserted {
-            Assertions.assertThat(
+            assertThat(
                 echoEnvoy.container.admin()
                     .isEndpointHealthy("echo2", echo2Envoy.container.ipAddress())
             ).isTrue()
-            Assertions.assertThat(
+            assertThat(
                 echo2Envoy.container.admin().isEndpointHealthy(
                     "echo",
                     echoEnvoy.container.ipAddress()
@@ -122,8 +122,8 @@ class IncomingPermissionsOriginalDestinationTest {
         )
 
         // then
-        Assertions.assertThat(response).isOk().isFrom(echoService2)
-        Assertions.assertThat(echo2Envoy.container).hasNoRBACDenials()
+        assertThat(response).isOk().isFrom(echoService2)
+        assertThat(echo2Envoy.container).hasNoRBACDenials()
     }
 
     @Test
@@ -134,9 +134,9 @@ class IncomingPermissionsOriginalDestinationTest {
         )
 
         // then
-        Assertions.assertThat(response).isForbidden()
+        assertThat(response).isForbidden()
 
-        Assertions.assertThat(echo2Envoy.container).hasOneAccessDenialWithActionBlock(
+        assertThat(echo2Envoy.container).hasOneAccessDenialWithActionBlock(
             protocol = "http",
             path = "/blocked-echo",
             method = "GET",

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
@@ -137,7 +137,7 @@ class IncomingPermissionsOriginalDestinationTest {
         Assertions.assertThat(response).isForbidden()
 
         Assertions.assertThat(echo2Envoy.container).hasOneAccessDenialWithActionBlock(
-            protocol = "https",
+            protocol = "http",
             path = "/blocked-echo",
             method = "GET",
             clientName = "echo",

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/IncomingPermissionsOriginalDestinationTest.kt
@@ -1,0 +1,148 @@
+package pl.allegro.tech.servicemesh.envoycontrol.permissions
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.hasNoRBACDenials
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.hasOneAccessDenialWithActionBlock
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isForbidden
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.isOk
+import pl.allegro.tech.servicemesh.envoycontrol.assertions.untilAsserted
+import pl.allegro.tech.servicemesh.envoycontrol.config.Echo1EnvoyAuthConfig
+import pl.allegro.tech.servicemesh.envoycontrol.config.consul.ConsulExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoy.EnvoyExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.envoycontrol.EnvoyControlExtension
+import pl.allegro.tech.servicemesh.envoycontrol.config.service.EchoServiceExtension
+
+class IncomingPermissionsOriginalDestinationTest {
+
+    companion object {
+
+        // language=yaml
+        private val echoYaml = """
+            node:
+              metadata:
+                proxy_settings:
+                  incoming:
+                    endpoints:
+                    - path: "/allowed-echo"
+                      unlistedClientsPolicy: blockAndLog
+                      clients: [echo, envoy-original-destination]
+                    - path: "/blocked-echo"
+                      unlistedClientsPolicy: blockAndLog
+                      clients: [echo2]
+                  outgoing:
+                    dependencies:
+                      - service: "echo"
+                      - service: "echo2"
+        """.trimIndent()
+
+        private val echoConfig = Echo1EnvoyAuthConfig.copy(configOverride = echoYaml)
+        private val failingEchoConfig =
+            Echo1EnvoyAuthConfig.copy(configOverride = echoYaml, serviceName = "failing-echo")
+
+        @JvmField
+        @RegisterExtension
+        val consul = ConsulExtension()
+        private const val prefix = "envoy-control.envoy.snapshot"
+
+        @JvmField
+        @RegisterExtension
+        val envoyControl = EnvoyControlExtension(
+            consul, mapOf(
+                "${prefix}.incoming-permissions.enabled" to true,
+                "${prefix}.outgoing-permissions.enabled" to true,
+                "${prefix}.routes.status.create-virtual-cluster" to true
+            )
+        )
+
+        @JvmField
+        @RegisterExtension
+        val echoService = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val echoService2 = EchoServiceExtension()
+
+        @JvmField
+        @RegisterExtension
+        val echoEnvoy = EnvoyExtension(envoyControl, config = echoConfig, localService = echoService)
+
+        @JvmField
+        @RegisterExtension
+        val echo2Envoy = EnvoyExtension(envoyControl, config = failingEchoConfig, localService = echoService2)
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        consul.server.operations.registerServiceWithEnvoyOnIngress(
+            echoEnvoy,
+            name = "echo",
+            tags = listOf("mtls:enabled")
+        )
+        consul.server.operations.registerServiceWithEnvoyOnIngress(
+            echo2Envoy,
+            name = "echo2",
+            tags = listOf("mtls:enabled")
+        )
+        waitForEnvoysInitialized()
+        echoEnvoy.recordRBACLogs()
+        echo2Envoy.recordRBACLogs()
+    }
+
+    private fun waitForEnvoysInitialized() {
+        untilAsserted {
+            Assertions.assertThat(
+                echoEnvoy.container.admin()
+                    .isEndpointHealthy("echo2", echo2Envoy.container.ipAddress())
+            ).isTrue()
+            Assertions.assertThat(
+                echo2Envoy.container.admin().isEndpointHealthy(
+                    "echo",
+                    echoEnvoy.container.ipAddress()
+                )
+            ).isTrue()
+        }
+    }
+
+    @AfterEach
+    fun cleanupTest() {
+        echoEnvoy.stopRecordingRBAC()
+        echo2Envoy.stopRecordingRBAC()
+    }
+
+    @Test
+    fun `should allow direct request when using orginal destination and echo service is specified as client`() {
+        // when
+        val response = echo2Envoy.ingressOperations.callServiceWithOriginalDst(
+            echoService2, "/allowed-echo", "echo", true
+        )
+
+        // then
+        Assertions.assertThat(response).isOk().isFrom(echoService2)
+        Assertions.assertThat(echo2Envoy.container).hasNoRBACDenials()
+    }
+
+    @Test
+    fun `should block direct request when using orginal destination and echo service is not specified as client`() {
+        // when
+        val response = echo2Envoy.ingressOperations.callServiceWithOriginalDst(
+            echoService2, "/blocked-echo", "echo"
+        )
+
+        // then
+        Assertions.assertThat(response).isForbidden()
+
+        Assertions.assertThat(echo2Envoy.container).hasOneAccessDenialWithActionBlock(
+            protocol = "https",
+            path = "/blocked-echo",
+            method = "GET",
+            clientName = "echo",
+            trustedClient = false,
+            clientIp = echoEnvoy.container.ipAddress().replaceAfterLast(".", "1")
+        )
+    }
+}


### PR DESCRIPTION
Adding new rules to rbac filter. Allowed clients should not be blocked, when they are using envoy-original-destination.