### PR TITLE
Added setting localityAware flag on subsetConfig for clusters with traffic splitting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [0.20.14]
 ### Changed
 - Added test to check circuit breaker metric value
+- Set "localityAware=true" for cluster subset config
 
 ## [0.20.13]
 ### Changed

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
@@ -257,6 +257,10 @@ class EnvoyClustersFactory(
                     .setLocalityWeightedLbConfig(Cluster.CommonLbConfig.LocalityWeightedLbConfig.getDefaultInstance())
                     .build()
             )
+            .setLbSubsetConfig(
+                Cluster.LbSubsetConfig.newBuilder(cluster.lbSubsetConfig)
+                    .setLocalityWeightAware(true)
+            )
             .also {
                 logger.debug("Created cluster config for traffic splitting: {}", it.toString())
             }

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactory.kt
@@ -260,6 +260,7 @@ class EnvoyClustersFactory(
             .setLbSubsetConfig(
                 Cluster.LbSubsetConfig.newBuilder(cluster.lbSubsetConfig)
                     .setLocalityWeightAware(true)
+                    .setScaleLocalityWeight(true)
             )
             .also {
                 logger.debug("Created cluster config for traffic splitting: {}", it.toString())

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactoryTest.kt
@@ -117,6 +117,7 @@ internal class EnvoyClustersFactoryTest {
                 assertThat(it.commonLbConfig.localityWeightedLbConfig).isNotNull
                 assertThat(it.lbSubsetConfig).isNotNull
                 assertThat(it.lbSubsetConfig.localityWeightAware).isTrue()
+                assertThat(it.lbSubsetConfig.scaleLocalityWeight).isTrue()
             }
     }
 
@@ -138,6 +139,7 @@ internal class EnvoyClustersFactoryTest {
                 assertThat(it.edsClusterConfig).isEqualTo(cluster1.edsClusterConfig)
                 assertThat(it.commonLbConfig.hasLocalityWeightedLbConfig()).isFalse()
                 assertThat(it.lbSubsetConfig.localityWeightAware).isFalse()
+                assertThat(it.lbSubsetConfig.scaleLocalityWeight).isFalse()
             }
     }
 

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/clusters/EnvoyClustersFactoryTest.kt
@@ -32,6 +32,7 @@ internal class EnvoyClustersFactoryTest {
                 DEFAULT_SERVICE_NAME to DEFAULT_CLUSTER_WEIGHTS
             )
             loadBalancing.trafficSplitting.zoneName = TRAFFIC_SPLITTING_ZONE
+            loadBalancing.trafficSplitting.zonesAllowingTrafficSplitting = listOf(CURRENT_ZONE)
         }
     }
 
@@ -112,7 +113,10 @@ internal class EnvoyClustersFactoryTest {
             .anySatisfy {
                 assertThat(it.name).isEqualTo(CLUSTER_NAME1)
                 assertThat(it.edsClusterConfig).isEqualTo(cluster1.edsClusterConfig)
+                assertThat(it.commonLbConfig).isNotNull
                 assertThat(it.commonLbConfig.localityWeightedLbConfig).isNotNull
+                assertThat(it.lbSubsetConfig).isNotNull
+                assertThat(it.lbSubsetConfig.localityWeightAware).isTrue()
             }
     }
 
@@ -133,6 +137,7 @@ internal class EnvoyClustersFactoryTest {
                 assertThat(it.name).isEqualTo(CLUSTER_NAME1)
                 assertThat(it.edsClusterConfig).isEqualTo(cluster1.edsClusterConfig)
                 assertThat(it.commonLbConfig.hasLocalityWeightedLbConfig()).isFalse()
+                assertThat(it.lbSubsetConfig.localityWeightAware).isFalse()
             }
     }
 

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ClusterCircuitBreakerDefaultSettingsTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/ClusterCircuitBreakerDefaultSettingsTest.kt
@@ -1,6 +1,7 @@
 package pl.allegro.tech.servicemesh.envoycontrol
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import pl.allegro.tech.servicemesh.envoycontrol.assertions.isFrom
@@ -81,6 +82,7 @@ internal class ClusterCircuitBreakerDefaultSettingsTest {
         assertThat(remainingRqMetric).isNotNull()
     }
 
+    @Tag("flaky")
     @Test
     fun `should have decreased remaining pending rq`() {
         consul.server.operations.registerServiceWithEnvoyOnIngress(name = "echo", extension = envoy)


### PR DESCRIPTION
This flag is needed for correct calculation of weights during load balancing (when two configs are present - localityLbConfig and subsetConfig)