### PR TITLE
java control plane 1.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Lists all changes with user impact.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+
+## [0.20.15]
+### Changed
+- Java-control-plane update to 1.0.45
+
 ## [0.20.14]
 ### Changed
 - Added test to check circuit breaker metric value

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     apply plugin: 'io.spring.dependency-management'
 
     project.ext.versions = [
-            java_controlplane : '1.0.37',
+            java_controlplane : '1.0.45',
             spring_boot       : '3.1.2',
             grpc              : '1.48.1',
             ecwid_consul      : '1.4.1',

--- a/envoy-control-core/src/main/java/pl/allegro/tech/servicemesh/envoycontrol/SimpleCache.java
+++ b/envoy-control-core/src/main/java/pl/allegro/tech/servicemesh/envoycontrol/SimpleCache.java
@@ -94,7 +94,7 @@ public class SimpleCache<T, U extends Snapshot> implements SnapshotCache<T, U> {
       XdsRequest request,
       Set<String> knownResourceNames,
       Consumer<Response> responseConsumer) {
-    return createWatch(ads, request, knownResourceNames, responseConsumer, false);
+    return createWatch(ads, request, knownResourceNames, responseConsumer, false, false);
   }
 
     /**
@@ -106,7 +106,8 @@ public class SimpleCache<T, U extends Snapshot> implements SnapshotCache<T, U> {
             XdsRequest request,
             Set<String> knownResourceNames,
             Consumer<Response> responseConsumer,
-            boolean hasClusterChanged) {
+            boolean hasClusterChanged,
+            boolean allowDefaultEmptyEdsUpdate) {
     Resources.ResourceType requestResourceType = request.getResourceType();
         Preconditions.checkNotNull(requestResourceType, "unsupported type URL %s",
                 request.getTypeUrl());
@@ -123,7 +124,7 @@ public class SimpleCache<T, U extends Snapshot> implements SnapshotCache<T, U> {
             U snapshot = snapshots.get(group);
             String version = snapshot == null ? "" : snapshot.version(requestResourceType, request.getResourceNamesList());
 
-            Watch watch = new Watch(ads, request, responseConsumer);
+            Watch watch = new Watch(ads, allowDefaultEmptyEdsUpdate, request, responseConsumer);
 
             if (snapshot != null) {
                 Set<String> requestedResources = ImmutableSet.copyOf(request.getResourceNamesList());

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/GroupChangeWatcher.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/GroupChangeWatcher.kt
@@ -44,14 +44,22 @@ internal class GroupChangeWatcher(
 
     override fun createWatch(
         ads: Boolean,
-        request: XdsRequest,
-        knownResourceNames: MutableSet<String>,
-        responseConsumer: Consumer<Response>,
-        hasClusterChanged: Boolean
+        request: XdsRequest?,
+        knownResourceNames: MutableSet<String>?,
+        responseConsumer: Consumer<Response>?,
+        hasClusterChanged: Boolean,
+        allowDefaultEmptyEdsUpdate: Boolean
     ): Watch {
         val oldGroups = cache.groups()
 
-        val watch = cache.createWatch(ads, request, knownResourceNames, responseConsumer, hasClusterChanged)
+        val watch = cache.createWatch(
+            ads,
+            request,
+            knownResourceNames,
+            responseConsumer,
+            hasClusterChanged,
+            allowDefaultEmptyEdsUpdate
+        )
         val groups = cache.groups()
         metrics.setCacheGroupsCount(groups.size)
         if (oldGroups != groups) {

--- a/envoy-control-core/src/test/java/pl/allegro/tech/servicemesh/envoycontrol/v3/SimpleCacheTest.java
+++ b/envoy-control-core/src/test/java/pl/allegro/tech/servicemesh/envoycontrol/v3/SimpleCacheTest.java
@@ -92,7 +92,9 @@ public class SimpleCacheTest {
                         .build()),
                 Collections.emptySet(),
                 responseTracker,
-                false);
+                false,
+                false
+            );
 
         assertThatWatchIsOpenWithNoResponses(new WatchAndTracker(watch, responseTracker));
     }
@@ -114,7 +116,9 @@ public class SimpleCacheTest {
                         .build()),
                 Collections.emptySet(),
                 responseTracker,
-                false);
+                false,
+                false
+            );
 
         assertThat(watch.isCancelled()).isFalse();
         assertThat(responseTracker.responses).isNotEmpty();
@@ -138,7 +142,9 @@ public class SimpleCacheTest {
                             .build()),
                     Collections.emptySet(),
                     responseTracker,
-                    false);
+                    false,
+                    false
+                );
 
             assertThat(watch.request().getTypeUrl()).isEqualTo(typeUrl);
             assertThat(watch.request().getResourceNamesList()).containsExactlyElementsOf(
@@ -166,7 +172,9 @@ public class SimpleCacheTest {
                         .build()),
                 Sets.newHashSet(""),
                 responseTracker,
-                true);
+                true,
+                false
+            );
 
         assertThat(watch.request().getTypeUrl()).isEqualTo(Resources.V3.ENDPOINT_TYPE_URL);
         assertThat(watch.request().getResourceNamesList()).containsExactlyElementsOf(
@@ -194,7 +202,9 @@ public class SimpleCacheTest {
                                             .build()),
                                     Collections.emptySet(),
                                     responseTracker,
-                                    false);
+                                    false,
+                                    false
+                                );
 
                             return new WatchAndTracker(watch, responseTracker);
                         }));
@@ -236,7 +246,9 @@ public class SimpleCacheTest {
                                             responseTracker.accept(r);
                                             responseOrderTracker.accept(r);
                                         },
-                                        false);
+                                        false,
+                                        false
+                                    );
 
                                 return new WatchAndTracker(watch, responseTracker);
                             }))
@@ -288,7 +300,9 @@ public class SimpleCacheTest {
                                             .build()),
                                     SNAPSHOT2.resources(typeUrl).keySet(),
                                     responseTracker,
-                                    false);
+                                    false,
+                                    false
+                                );
 
                             return new WatchAndTracker(watch, responseTracker);
                         }));
@@ -333,7 +347,9 @@ public class SimpleCacheTest {
                                             .build()),
                                     SNAPSHOT2.resources(typeUrl).keySet(),
                                     responseTracker,
-                                    false);
+                                    false,
+                                    false
+                                );
 
                             return new WatchAndTracker(watch, responseTracker);
                         }));
@@ -366,7 +382,9 @@ public class SimpleCacheTest {
                                             .build()),
                                     SNAPSHOT1.resources(typeUrl).keySet(),
                                     responseTracker,
-                                    false);
+                                    false,
+                                    false
+                                );
 
                             return new WatchAndTracker(watch, responseTracker);
                         }));
@@ -403,7 +421,9 @@ public class SimpleCacheTest {
                                             .build()),
                                     Collections.emptySet(),
                                     responseTracker,
-                                    false);
+                                    false,
+                                    false
+                                );
 
                             return new WatchAndTracker(watch, responseTracker);
                         }));
@@ -435,7 +455,9 @@ public class SimpleCacheTest {
                         .build()),
                 Collections.singleton(ROUTE_NAME),
                 responseTracker,
-                false);
+                false,
+                false
+            );
 
         assertThatWatchIsOpenWithNoResponses(new WatchAndTracker(watch, responseTracker));
     }
@@ -475,7 +497,9 @@ public class SimpleCacheTest {
                         .build()),
                 Collections.emptySet(),
                 r -> { },
-                false);
+                false,
+                false
+            );
 
         // clearSnapshot should fail and the snapshot should be left untouched
         assertThat(cache.clearSnapshot(SingleNodeGroup.GROUP)).isFalse();
@@ -502,7 +526,9 @@ public class SimpleCacheTest {
                         .build()),
                 Collections.emptySet(),
                 r -> { },
-                false);
+                false,
+                false
+            );
 
         assertThat(cache.groups()).containsExactly(SingleNodeGroup.GROUP);
     }

--- a/envoy-control-core/src/test/java/pl/allegro/tech/servicemesh/envoycontrol/v3/SimpleCacheWithMissingEndpointsTest.java
+++ b/envoy-control-core/src/test/java/pl/allegro/tech/servicemesh/envoycontrol/v3/SimpleCacheWithMissingEndpointsTest.java
@@ -61,7 +61,9 @@ public class SimpleCacheWithMissingEndpointsTest extends SimpleCacheTest {
                         .build()),
                 Collections.emptySet(),
                 responseTracker,
-                false);
+                false,
+                false
+            );
 
         assertThatWatchReceivesSnapshotWithMissingResources(new WatchAndTracker(watch, responseTracker), SNAPSHOT_WITH_MISSING_RESOURCES);
     }

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/SnapshotUpdaterTest.kt
@@ -1121,7 +1121,8 @@ class SnapshotUpdaterTest {
             request: XdsRequest,
             knownResourceNames: MutableSet<String>,
             responseConsumer: Consumer<Response>,
-            hasClusterChanged: Boolean
+            hasClusterChanged: Boolean,
+            allowDefaultEmptyEdsUpdate: Boolean
         ): Watch {
             throw UnsupportedOperationException("not used in testing")
         }

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
@@ -39,7 +39,7 @@ class EnvoyContainer(
         private const val ADMIN_PORT = 10000
 
         private const val MIN_SUPPORTED_ENVOY_VERSION = "v1.22.7"
-        private const val MAX_SUPPORTED_ENVOY_VERSION = "v1.30.2" // todo: v1.28.0+ - OutlierDetectionTest breaks
+        private const val MAX_SUPPORTED_ENVOY_VERSION = "v1.30.4"
 
         val DEFAULT_IMAGE = run {
             val version =

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/config/envoy/EnvoyContainer.kt
@@ -39,7 +39,7 @@ class EnvoyContainer(
         private const val ADMIN_PORT = 10000
 
         private const val MIN_SUPPORTED_ENVOY_VERSION = "v1.22.7"
-        private const val MAX_SUPPORTED_ENVOY_VERSION = "v1.24.0"
+        private const val MAX_SUPPORTED_ENVOY_VERSION = "v1.30.2" // todo: v1.28.0+ - OutlierDetectionTest breaks
 
         val DEFAULT_IMAGE = run {
             val version =

--- a/tools/envoy/Dockerfile
+++ b/tools/envoy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.24.0
+FROM envoyproxy/envoy:v1.30.4
 
 ENV PORT=9999:9999
 ENV PORT=80:80


### PR DESCRIPTION
same update with SimpleCache removed in [this PR](https://github.com/allegro/envoy-control/pull/421)

SimpleCache is a class that was copied from java-control-plane to add some custom logic - this logic is now in java-control-plane, but for safety I am leaving it in separate PR.