### PR TITLE
fix jwt impacting lds cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Lists all changes with user impact.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.20.17]
+### Fixed
+- Fix JWT provider configuration to not impact lds cache
+
 ## [0.20.16]
 ### Changed
 - Add JWT failure reason to metadata and use it in jwt-status field on denied requests


### PR DESCRIPTION
https://github.com/allegro/envoy-control/pull/419 introduced a problem with lds cache - presumably there was a race condition in building JwtProvider configuration.
Now JwtProviders are built early and specific configuration of them is sent based on envoy proxy version.