### PR TITLE
Add service_id to filter metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Lists all changes with user impact.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.20.20]
+### Changed
+- Added service-id property to node metadata
+
 ## [0.20.19]
 ### Changed
 - Added http compression filter properties to node metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [0.20.20]
 ### Changed
-- Added service-id property to node metadata
+- Added service_id property to filter metadata
 
 ## [0.20.19]
 ### Changed

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/Groups.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/Groups.kt
@@ -5,6 +5,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.snapshot.AccessLogFiltersPropert
 sealed class Group {
     abstract val communicationMode: CommunicationMode
     abstract val serviceName: String
+    abstract val serviceId: String?
     abstract val discoveryServiceName: String?
     abstract val proxySettings: ProxySettings
     abstract val pathNormalizationConfig: PathNormalizationConfig
@@ -15,6 +16,7 @@ sealed class Group {
 data class ServicesGroup(
     override val communicationMode: CommunicationMode,
     override val serviceName: String = "",
+    override val serviceId: String? = null,
     override val discoveryServiceName: String? = null,
     override val proxySettings: ProxySettings = ProxySettings(),
     override val pathNormalizationConfig: PathNormalizationConfig = PathNormalizationConfig(),
@@ -25,12 +27,13 @@ data class ServicesGroup(
 data class AllServicesGroup(
     override val communicationMode: CommunicationMode,
     override val serviceName: String = "",
+    override val serviceId: String? = null,
     override val discoveryServiceName: String? = null,
     override val proxySettings: ProxySettings = ProxySettings(),
     override val pathNormalizationConfig: PathNormalizationConfig = PathNormalizationConfig(),
     override val listenersConfig: ListenersConfig? = null,
     override val compressionConfig: CompressionConfig = CompressionConfig(),
-    ) : Group()
+) : Group()
 
 data class PathNormalizationConfig(
     val normalizationEnabled: Boolean? = null,

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/Groups.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/Groups.kt
@@ -5,7 +5,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.snapshot.AccessLogFiltersPropert
 sealed class Group {
     abstract val communicationMode: CommunicationMode
     abstract val serviceName: String
-    abstract val serviceId: String?
+    abstract val serviceId: Int?
     abstract val discoveryServiceName: String?
     abstract val proxySettings: ProxySettings
     abstract val pathNormalizationConfig: PathNormalizationConfig
@@ -16,7 +16,7 @@ sealed class Group {
 data class ServicesGroup(
     override val communicationMode: CommunicationMode,
     override val serviceName: String = "",
-    override val serviceId: String? = null,
+    override val serviceId: Int? = null,
     override val discoveryServiceName: String? = null,
     override val proxySettings: ProxySettings = ProxySettings(),
     override val pathNormalizationConfig: PathNormalizationConfig = PathNormalizationConfig(),
@@ -27,7 +27,7 @@ data class ServicesGroup(
 data class AllServicesGroup(
     override val communicationMode: CommunicationMode,
     override val serviceName: String = "",
-    override val serviceId: String? = null,
+    override val serviceId: Int? = null,
     override val discoveryServiceName: String? = null,
     override val proxySettings: ProxySettings = ProxySettings(),
     override val pathNormalizationConfig: PathNormalizationConfig = PathNormalizationConfig(),

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroup.kt
@@ -174,6 +174,7 @@ class MetadataNodeGroup(
     private fun createV3Group(node: NodeV3): Group {
         val nodeMetadata = NodeMetadata(node.metadata, properties)
         val serviceName = serviceName(nodeMetadata)
+        val serviceId = nodeMetadata.serviceId
         val discoveryServiceName = nodeMetadata.discoveryServiceName
         val proxySettings = proxySettings(nodeMetadata)
         val listenersConfig = createListenersConfig(node.id, node.metadata, node.userAgentBuildVersion)
@@ -182,6 +183,7 @@ class MetadataNodeGroup(
                 AllServicesGroup(
                     nodeMetadata.communicationMode,
                     serviceName,
+                    serviceId,
                     discoveryServiceName,
                     proxySettings,
                     nodeMetadata.pathNormalizationConfig,
@@ -192,6 +194,7 @@ class MetadataNodeGroup(
                 ServicesGroup(
                     nodeMetadata.communicationMode,
                     serviceName,
+                    serviceId,
                     discoveryServiceName,
                     proxySettings,
                     nodeMetadata.pathNormalizationConfig,

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
@@ -28,7 +28,7 @@ class NodeMetadata(metadata: Struct, properties: SnapshotProperties) {
         .fieldsMap["service_name"]
         ?.stringValue
 
-    val serviceId: String? = metadata.fieldsMap["service_id"]?.stringValue
+    val serviceId: Int? = metadata.fieldsMap["service_id"]?.numberValue?.toInt()
 
     val discoveryServiceName: String? = metadata
         .fieldsMap["discovery_service_name"]

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/NodeMetadata.kt
@@ -28,6 +28,8 @@ class NodeMetadata(metadata: Struct, properties: SnapshotProperties) {
         .fieldsMap["service_name"]
         ?.stringValue
 
+    val serviceId: String? = metadata.fieldsMap["service_id"]?.stringValue
+
     val discoveryServiceName: String? = metadata
         .fieldsMap["discovery_service_name"]
         ?.stringValue

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactory.kt
@@ -78,7 +78,7 @@ class LuaFilterFactory(private val snapshotProperties: SnapshotProperties) {
                 )
             ),
             "service_name" to StringPropertyLua(group.serviceName),
-            "service_id" to StringPropertyLua(group.serviceId ?: ""),
+            "service_id" to StringPropertyLua(group.serviceId?.toString().orEmpty()),
             "discovery_service_name" to StringPropertyLua(group.discoveryServiceName ?: ""),
             "rbac_headers_to_log" to ListPropertyLua(
                 snapshotProperties.incomingPermissions.headersToLogInRbac.map(::StringPropertyLua)

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactory.kt
@@ -78,6 +78,7 @@ class LuaFilterFactory(private val snapshotProperties: SnapshotProperties) {
                 )
             ),
             "service_name" to StringPropertyLua(group.serviceName),
+            "service_id" to StringPropertyLua(group.serviceId ?: ""),
             "discovery_service_name" to StringPropertyLua(group.discoveryServiceName ?: ""),
             "rbac_headers_to_log" to ListPropertyLua(
                 snapshotProperties.incomingPermissions.headersToLogInRbac.map(::StringPropertyLua)

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/EnvoySnapshotFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/EnvoySnapshotFactoryTest.kt
@@ -404,15 +404,15 @@ class EnvoySnapshotFactoryTest {
             false -> null
         }
         return ServicesGroup(
-            mode,
-            serviceName,
-            discoveryServiceName,
-            ProxySettings().with(
+            communicationMode = mode,
+            serviceName = serviceName,
+            discoveryServiceName = discoveryServiceName,
+            proxySettings = ProxySettings().with(
                 serviceDependencies = serviceDependencies(*dependencies),
                 rateLimitEndpoints = rateLimitEndpoints
             ),
-            PathNormalizationConfig(),
-            listenersConfig
+            pathNormalizationConfig = PathNormalizationConfig(),
+            listenersConfig = listenersConfig
         )
     }
 
@@ -430,15 +430,15 @@ class EnvoySnapshotFactoryTest {
             false -> null
         }
         return AllServicesGroup(
-            mode,
-            serviceName,
-            discoveryServiceName,
-            ProxySettings().with(
+            communicationMode = mode,
+            serviceName = serviceName,
+            discoveryServiceName = discoveryServiceName,
+            proxySettings = ProxySettings().with(
                 serviceDependencies = serviceDependencies(*dependencies),
                 defaultServiceSettings = defaultServiceSettings
             ),
-            PathNormalizationConfig(),
-            listenersConfig
+            pathNormalizationConfig = PathNormalizationConfig(),
+            listenersConfig = listenersConfig
         )
     }
 

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
@@ -161,6 +161,32 @@ class MetadataNodeGroupTest {
     }
 
     @Test
+    fun `should set serviceId to group if present`() {
+        // given
+        val nodeGroup = MetadataNodeGroup(createSnapshotProperties(outgoingPermissions = true))
+        val node = nodeV3(serviceId = 777)
+
+        // when
+        val group = nodeGroup.hash(node)
+
+        // then
+        assertThat(group.serviceId).isEqualTo(777)
+    }
+
+    @Test
+    fun `should not set serviceId to group if not present`() {
+        // given
+        val nodeGroup = MetadataNodeGroup(createSnapshotProperties(outgoingPermissions = true))
+        val node = nodeV3()
+
+        // when
+        val group = nodeGroup.hash(node)
+
+        // then
+        assertThat(group.serviceId).isNull()
+    }
+
+    @Test
     fun `should not include service settings when incoming permissions are disabled`() {
         // given
         val nodeGroup = MetadataNodeGroup(createSnapshotProperties(outgoingPermissions = true))

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/MetadataNodeGroupTest.kt
@@ -163,14 +163,15 @@ class MetadataNodeGroupTest {
     @Test
     fun `should set serviceId to group if present`() {
         // given
+        val expectedServiceId = 777
         val nodeGroup = MetadataNodeGroup(createSnapshotProperties(outgoingPermissions = true))
-        val node = nodeV3(serviceId = 777)
+        val node = nodeV3(serviceId = expectedServiceId)
 
         // when
         val group = nodeGroup.hash(node)
 
         // then
-        assertThat(group.serviceId).isEqualTo(777)
+        assertThat(group.serviceId).isEqualTo(expectedServiceId)
     }
 
     @Test

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/groups/TestNodeFactory.kt
@@ -13,6 +13,7 @@ fun nodeV3(
     serviceDependencies: Set<String> = emptySet(),
     ads: Boolean? = null,
     serviceName: String? = null,
+    serviceId: Int? = null,
     discoveryServiceName: String? = null,
     incomingSettings: Boolean = false,
     clients: List<String> = listOf("client1"),
@@ -29,6 +30,8 @@ fun nodeV3(
     serviceName?.let {
         meta.putFields("service_name", string(serviceName))
     }
+
+    serviceId?.let { meta.putFields("service_id", integer(serviceId)) }
 
     discoveryServiceName?.let {
         meta.putFields("discovery_service_name", string(discoveryServiceName))

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactoryTest.kt
@@ -17,7 +17,7 @@ internal class LuaFilterFactoryTest {
     val properties = SnapshotProperties().also { it.incomingPermissions = IncomingPermissionsProperties() }
 
     @Test
-    fun `should create metadata with service name and discovery service name and service-id`() {
+    fun `should create metadata with service name and discovery service name`() {
         // given
         val expectedServiceName = "service-1"
         val expectedDiscoveryServiceName = "consul-service-1"
@@ -46,15 +46,14 @@ internal class LuaFilterFactoryTest {
     }
 
     @Test
-    fun `should create metadata with serviceId`() {
+    fun `should create filter metadata with serviceId`() {
         // given
         val expectedServiceId = 777
-
-        val group: Group = ServicesGroup(communicationMode = CommunicationMode.XDS, serviceId = expectedServiceId)
-        val factory = LuaFilterFactory(properties)
+        val group = ServicesGroup(communicationMode = CommunicationMode.XDS, serviceId = expectedServiceId)
+        val luaFilterFactory = LuaFilterFactory(properties)
 
         // when
-        val metadata = factory.ingressScriptsMetadata(group, currentZone = "dc1")
+        val metadata = luaFilterFactory.ingressScriptsMetadata(group, currentZone = "dc1")
 
         val actualServiceId = metadata
             .getFilterMetadataOrThrow("envoy.filters.http.lua")
@@ -66,13 +65,13 @@ internal class LuaFilterFactoryTest {
     }
 
     @Test
-    fun `should create metadata with empty serviceId`() {
+    fun `should create filter metadata with empty serviceId`() {
         // given
-        val group: Group = ServicesGroup(communicationMode = CommunicationMode.XDS)
-        val factory = LuaFilterFactory(properties)
+        val group = ServicesGroup(communicationMode = CommunicationMode.XDS)
+        val luaFilterFactory = LuaFilterFactory(properties)
 
         // when
-        val metadata = factory.ingressScriptsMetadata(group, currentZone = "dc1")
+        val metadata = luaFilterFactory.ingressScriptsMetadata(group, currentZone = "dc1")
 
         val actualServiceId = metadata
             .getFilterMetadataOrThrow("envoy.filters.http.lua")

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/LuaFilterFactoryTest.kt
@@ -17,13 +17,15 @@ internal class LuaFilterFactoryTest {
     val properties = SnapshotProperties().also { it.incomingPermissions = IncomingPermissionsProperties() }
 
     @Test
-    fun `should create metadata with service name and discovery service name`() {
+    fun `should create metadata with service name and discovery service name and service-id`() {
         // given
         val expectedServiceName = "service-1"
         val expectedDiscoveryServiceName = "consul-service-1"
+        val expectedServiceId = "777"
         val group: Group = ServicesGroup(
             communicationMode = CommunicationMode.XDS,
             serviceName = expectedServiceName,
+            serviceId = expectedServiceId,
             discoveryServiceName = expectedDiscoveryServiceName
         )
         val factory = LuaFilterFactory(properties)
@@ -40,9 +42,15 @@ internal class LuaFilterFactoryTest {
             .getFieldsOrThrow("discovery_service_name")
             .stringValue
 
+        val givenServiceId = metadata
+            .getFilterMetadataOrThrow("envoy.filters.http.lua")
+            .getFieldsOrThrow("service_id")
+            .stringValue
+
         // then
         assertThat(givenServiceName).isEqualTo(expectedServiceName)
         assertThat(givenDiscoveryServiceName).isEqualTo(expectedDiscoveryServiceName)
+        assertThat(givenServiceId).isEqualTo(expectedServiceId)
     }
 
     @Test

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/routes/EnvoyIngressRoutesFactoryTest.kt
@@ -124,10 +124,10 @@ internal class EnvoyIngressRoutesFactoryTest {
             )
         )
         val group = ServicesGroup(
-            CommunicationMode.XDS,
-            "service_1",
-            "service_1",
-            proxySettingsOneEndpoint
+            communicationMode = CommunicationMode.XDS,
+            serviceName = "service_1",
+            discoveryServiceName = "service_1",
+            proxySettings = proxySettingsOneEndpoint
         )
 
         // when
@@ -203,10 +203,10 @@ internal class EnvoyIngressRoutesFactoryTest {
             )
         )
         val group = ServicesGroup(
-            CommunicationMode.XDS,
-            "service_1",
-            "service_1",
-            proxySettingsOneEndpoint
+            communicationMode = CommunicationMode.XDS,
+            serviceName = "service_1",
+            discoveryServiceName = "service_1",
+            proxySettings = proxySettingsOneEndpoint
         )
 
         // when

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/utils/GroupsOperations.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/utils/GroupsOperations.kt
@@ -24,15 +24,15 @@ fun createServicesGroup(
     listenersConfig: ListenersConfig? = createListenersConfig(snapshotProperties)
 ): ServicesGroup {
     return ServicesGroup(
-        mode,
-        serviceName,
-        discoveryServiceName,
-        ProxySettings().with(
+        communicationMode = mode,
+        serviceName = serviceName,
+        discoveryServiceName = discoveryServiceName,
+        proxySettings = ProxySettings().with(
             serviceDependencies = serviceDependencies(*dependencies),
             rateLimitEndpoints = rateLimitEndpoints
         ),
-        PathNormalizationConfig(),
-        listenersConfig
+        pathNormalizationConfig = PathNormalizationConfig(),
+        listenersConfig = listenersConfig
     )
 }
 
@@ -50,15 +50,15 @@ fun createAllServicesGroup(
         false -> null
     }
     return AllServicesGroup(
-        mode,
-        serviceName,
-        discoveryServiceName,
-        ProxySettings().with(
+        communicationMode = mode,
+        serviceName = serviceName,
+        discoveryServiceName = discoveryServiceName,
+        proxySettings = ProxySettings().with(
             serviceDependencies = serviceDependencies(*dependencies),
             defaultServiceSettings = defaultServiceSettings
         ),
-        PathNormalizationConfig(),
-        listenersConfig
+        pathNormalizationConfig = PathNormalizationConfig(),
+        listenersConfig = listenersConfig
     )
 }
 


### PR DESCRIPTION
Added `service_id` to filter metadata. https://github.com/allegro-internal/flex-roadmap/issues/644

## Testing process

 - If `service_id` is present in node metadata it will be passed to the filters metadata.
<img width="411" alt="image" src="https://github.com/user-attachments/assets/ceb52b29-5d45-40b4-a841-fafe57a9d138">


- If missing, the `service_id` value will be empty.
<img width="411" alt="image" src="https://github.com/user-attachments/assets/1048bf01-17f8-4672-911f-c5747c7069f9">


