### PR TITLE
allegro-internal/flex-roadmap#1371 | Fix JWT filter generation to correctly resolve custom roles in endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Lists all changes with user impact.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.22.20]
+### Fixed
+- Fixed JWT filter role resolution so role-based OAuth clients are expanded correctly when generating JWT authentication rules
+
 ## [0.22.19]
 ### Changed
 - Updated Spring Boot to 3.4.5

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactory.kt
@@ -16,7 +16,6 @@ import io.envoyproxy.envoy.extensions.filters.http.jwt_authn.v3.RequirementRule
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter
 import io.envoyproxy.envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
 import io.envoyproxy.envoy.type.matcher.v3.RegexMatcher
-import pl.allegro.tech.servicemesh.envoycontrol.groups.ClientWithSelector
 import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
 import pl.allegro.tech.servicemesh.envoycontrol.groups.IncomingEndpoint
 import pl.allegro.tech.servicemesh.envoycontrol.groups.PathMatchingType

--- a/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactory.kt
+++ b/envoy-control-core/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactory.kt
@@ -16,9 +16,11 @@ import io.envoyproxy.envoy.extensions.filters.http.jwt_authn.v3.RequirementRule
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter
 import io.envoyproxy.envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
 import io.envoyproxy.envoy.type.matcher.v3.RegexMatcher
+import pl.allegro.tech.servicemesh.envoycontrol.groups.ClientWithSelector
 import pl.allegro.tech.servicemesh.envoycontrol.groups.Group
 import pl.allegro.tech.servicemesh.envoycontrol.groups.IncomingEndpoint
 import pl.allegro.tech.servicemesh.envoycontrol.groups.PathMatchingType
+import pl.allegro.tech.servicemesh.envoycontrol.groups.Role
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.JwtFilterProperties
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.OAuthProvider
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.ProviderName
@@ -51,7 +53,9 @@ class JwtFilterFactory(
                         JwtAuthentication.newBuilder().putAllProviders(
                             selectedJwtProviders
                         )
-                            .addAllRules(createRules(group.proxySettings.incoming.endpoints))
+                            .addAllRules(createRules(
+                                group.proxySettings.incoming.endpoints,
+                                group.proxySettings.incoming.roles))
                             .build()
                     )
                 )
@@ -62,13 +66,29 @@ class JwtFilterFactory(
     }
 
     private fun shouldCreateFilter(group: Group): Boolean {
-        return properties.providers.isNotEmpty() && group.proxySettings.incoming.endpoints.any {
-            it.oauth != null || containsClientsWithSelector(it)
+        if (properties.providers.isEmpty()) {
+            return false
+        }
+
+        val roles = group.proxySettings.incoming.roles
+        return group.proxySettings.incoming.endpoints.any { endpoint ->
+            endpoint.oauth != null || containsClientsWithSelector(endpoint, roles)
         }
     }
 
-    private fun containsClientsWithSelector(it: IncomingEndpoint) =
-        clientToOAuthProviderName.keys.intersect(it.clients.map { it.name }).isNotEmpty()
+    private fun containsClientsWithSelector(endpoint: IncomingEndpoint, roles: List<Role>): Boolean {
+        return resolveClientNames(endpoint, roles).any(clientToOAuthProviderName::containsKey)
+    }
+
+    private fun resolveClientNames(endpoint: IncomingEndpoint, roles: List<Role>): Set<String> {
+        if (roles.isEmpty()) {
+            return endpoint.clients.map { it.name }.toSet()
+        }
+
+        return endpoint.clients.flatMap { clientOrRole ->
+            roles.find { it.name == clientOrRole.name }?.clients ?: setOf(clientOrRole)
+        }.map { it.name }.toSet()
+    }
 
     private fun getJwtProviders(failedStatusInMetadataEnabled: Boolean): Map<ProviderName, JwtProvider> =
         properties.providers.entries.associate {
@@ -99,19 +119,20 @@ class JwtFilterFactory(
         return jwtProvider.build()
     }
 
-    private fun createRules(endpoints: List<IncomingEndpoint>): Set<RequirementRule> {
-        return endpoints.flatMap(this::createRulesForEndpoint).toSet()
+    private fun createRules(endpoints: List<IncomingEndpoint>, roles: List<Role>): Set<RequirementRule> {
+        return endpoints.flatMap { createRulesForEndpoint(it, roles) }.toSet()
     }
 
-    private fun createRulesForEndpoint(endpoint: IncomingEndpoint): Set<RequirementRule> {
+    private fun createRulesForEndpoint(endpoint: IncomingEndpoint, roles: List<Role>): Set<RequirementRule> {
         val providers = mutableSetOf<String>()
 
         if (endpoint.oauth != null) {
             providers.add(endpoint.oauth.provider)
         }
 
-        providers.addAll(endpoint.clients.filter { it.name in clientToOAuthProviderName.keys }
-            .mapNotNull { clientToOAuthProviderName[it.name] })
+        val resolvedClientNames = resolveClientNames(endpoint, roles)
+        providers.addAll(resolvedClientNames.filter { it in clientToOAuthProviderName.keys }
+            .mapNotNull { clientToOAuthProviderName[it] })
 
         if (providers.isEmpty()) {
             return emptySet()

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactoryTest.kt
@@ -150,11 +150,12 @@ internal class JwtFilterFactoryTest {
     @Test
     fun `should create JWT filter when endpoint clients contain a role that resolves to an OAuth client`() {
         // given
-        val roleName = "test-role"
-        val oauthClientName = "oauth"
+        val roleName = "my-role"
+        val client = "oauth"
+        val selector = "team1"
         val role = Role(
             name = roleName,
-            clients = setOf(ClientWithSelector.create(oauthClientName, null))
+            clients = setOf(ClientWithSelector.create(client, selector))
         )
         val group = ServicesGroup(
             CommunicationMode.ADS, proxySettings = ProxySettings(
@@ -192,10 +193,12 @@ internal class JwtFilterFactoryTest {
     @Test
     fun `should not create JWT filter when role resolves to clients that are not OAuth clients`() {
         // given
-        val roleName = "test-role"
+        val roleName = "my-role"
+        val client = "non-oauth-client"
+        val selector = "team1"
         val role = Role(
             name = roleName,
-            clients = setOf(ClientWithSelector.create("non-oauth-client", null))
+            clients = setOf(ClientWithSelector.create(client, selector))
         )
         val group = ServicesGroup(
             CommunicationMode.ADS, proxySettings = ProxySettings(

--- a/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactoryTest.kt
+++ b/envoy-control-core/src/test/kotlin/pl/allegro/tech/servicemesh/envoycontrol/snapshot/resource/listeners/filters/JwtFilterFactoryTest.kt
@@ -13,6 +13,7 @@ import pl.allegro.tech.servicemesh.envoycontrol.groups.Incoming
 import pl.allegro.tech.servicemesh.envoycontrol.groups.IncomingEndpoint
 import pl.allegro.tech.servicemesh.envoycontrol.groups.OAuth
 import pl.allegro.tech.servicemesh.envoycontrol.groups.ProxySettings
+import pl.allegro.tech.servicemesh.envoycontrol.groups.Role
 import pl.allegro.tech.servicemesh.envoycontrol.groups.ServicesGroup
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.JwtFilterProperties
 import pl.allegro.tech.servicemesh.envoycontrol.snapshot.OAuthProvider
@@ -144,6 +145,78 @@ internal class JwtFilterFactoryTest {
         // then
         assertThat(generatedFilter).isNotNull
         assertThat(generatedFilter).isEqualTo(expectedJwtFilter)
+    }
+
+    @Test
+    fun `should create JWT filter when endpoint clients contain a role that resolves to an OAuth client`() {
+        // given
+        val roleName = "test-role"
+        val oauthClientName = "oauth"
+        val role = Role(
+            name = roleName,
+            clients = setOf(ClientWithSelector.create(oauthClientName, null))
+        )
+        val group = ServicesGroup(
+            CommunicationMode.ADS, proxySettings = ProxySettings(
+                Incoming(
+                    endpoints = listOf(
+                        IncomingEndpoint(
+                            path = "/",
+                            clients = setOf(ClientWithSelector.create(roleName, null)),
+                            oauth = null
+                        )
+                    ),
+                    roles = listOf(role)
+                )
+            )
+        )
+        val expectedJwtFilter = getJwtFilter(
+            singleProviderJson(
+                """ 
+            "requires": {
+                "requiresAny": {
+                    "requirements": [{"providerName": "provider"}, {"allowMissingOrFailed": {} }]
+                 }
+            }"""
+            )
+        )
+
+        // when
+        val generatedFilter = jwtFilterFactory.createJwtFilter(group)
+
+        // then
+        assertThat(generatedFilter).isNotNull
+        assertThat(generatedFilter).isEqualTo(expectedJwtFilter)
+    }
+
+    @Test
+    fun `should not create JWT filter when role resolves to clients that are not OAuth clients`() {
+        // given
+        val roleName = "test-role"
+        val role = Role(
+            name = roleName,
+            clients = setOf(ClientWithSelector.create("non-oauth-client", null))
+        )
+        val group = ServicesGroup(
+            CommunicationMode.ADS, proxySettings = ProxySettings(
+                Incoming(
+                    endpoints = listOf(
+                        IncomingEndpoint(
+                            path = "/",
+                            clients = setOf(ClientWithSelector.create(roleName, null)),
+                            oauth = null
+                        )
+                    ),
+                    roles = listOf(role)
+                )
+            )
+        )
+
+        // when
+        val generatedFilter = jwtFilterFactory.createJwtFilter(group)
+
+        // then
+        assertThat(generatedFilter).isNull()
     }
 
     private fun getJwtFilter(providersJson: String): HttpFilter? {


### PR DESCRIPTION
## Description

This PR fixes a bug in the JWT filter generation logic where clients defined via custom roles were being silently ignored. 

Previously, if an endpoint used a role (e.g., `role-actor`) instead of inline clients, the JWT filter generation skipped them because the role name didn't directly match any OAuth provider keys. 

### Root Cause
The bug occurred because `JwtFilterFactory.createRules()` was being called without the `roles` context. When `endpoint.clients` contained role names that depended on JWT validation, the code checked the literal role name against the OAuth provider keys. Finding no match, it silently skipped generating the JWT rules. 

`RBACFilterFactory` was already handling this correctly by utilizing `resolveClientsWithSelectors()`.

### What was changed?
* Updated the JWT filter generation flow to properly resolve roles before checking them against OAuth provider keys.
* Passed the `roles` context into `JwtFilterFactory.createRules()` (matching the correct behavior already present in `RBACFilterFactory` via `resolveClientsWithSelectors()`) so that underlying clients within a role are correctly expanded and processed for JWT rules.

**Examples:**

✅ **Working previously (Inline clients):**
```yaml
metadata:
  proxy_settings:
    incoming:
      endpoints:
        - path: /example
          methods: [GET]
          clients: [service-first, oauth-prefix:team1] # Worked fine
```

❌ **Failing previously, now fixed (Role-based clients):**
```yaml
metadata:
  proxy_settings:
    incoming:
      endpoints:
        - path: /example
          methods: [GET]
          clients: [role-actor] # Previously skipped by JwtFilterFactory
    roles:
      - clients: [service-first, oauth-prefix:team1]
        name: role-actor
```
