### PR TITLE
Fix cumulative counter assertion in TlsBasedAuthenticationTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Lists all changes with user impact.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [0.22.20]
+### Fixed
+- Fixed cumulative counter assertion in `TlsBasedAuthenticationTest`
+
 ## [0.22.19]
 ### Changed
 - Updated Spring Boot to 3.4.5

--- a/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/TlsBasedAuthenticationTest.kt
+++ b/envoy-control-tests/src/main/kotlin/pl/allegro/tech/servicemesh/envoycontrol/permissions/TlsBasedAuthenticationTest.kt
@@ -199,6 +199,10 @@ internal class TlsBasedAuthenticationTest {
             assertThat(echo2endpoints).isEqualTo(2)
         }
 
+        // snapshot cumulative counters before making requests
+        val plaintextMatchBefore = echo1Envoy.container.admin().statValue("cluster.echo2.plaintext_match.total_match_count")?.toInt() ?: 0
+        val mtlsMatchBefore = echo1Envoy.container.admin().statValue("cluster.echo2.mtls_match.total_match_count")?.toInt() ?: 0
+
         // when
         val callStats = echo1Envoy.egressOperations.callServiceRepeatedly(
                 service = "echo2",
@@ -214,11 +218,11 @@ internal class TlsBasedAuthenticationTest {
         assertThat(callStats.hits(service1)).isEqualTo(1)
         assertThat(callStats.hits(service2)).isEqualTo(1)
 
-        val defaultToPlaintextMatchesCount = echo1Envoy.container.admin().statValue("cluster.echo2.plaintext_match.total_match_count")?.toInt()
-        assertThat(defaultToPlaintextMatchesCount).isEqualTo(1)
+        val plaintextMatchAfter = echo1Envoy.container.admin().statValue("cluster.echo2.plaintext_match.total_match_count")?.toInt() ?: 0
+        assertThat(plaintextMatchAfter - plaintextMatchBefore).isEqualTo(1)
 
-        val enableMTLSMatchesCount = echo1Envoy.container.admin().statValue("cluster.echo2.mtls_match.total_match_count")?.toInt()
-        assertThat(enableMTLSMatchesCount).isEqualTo(1)
+        val mtlsMatchAfter = echo1Envoy.container.admin().statValue("cluster.echo2.mtls_match.total_match_count")?.toInt() ?: 0
+        assertThat(mtlsMatchAfter - mtlsMatchBefore).isEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
### Description

The test `should encrypt traffic between selected services even if only one endpoint supports mtls` was consistently failing with:
```text
expected: 1
but was: 2
```

### Root Cause

Envoy stat counters (`cluster.echo2.mtls_match.total_match_count` and `cluster.echo2.plaintext_match.total_match_count`) are cumulative. They accumulate across the entire Envoy container lifetime and are never reset between tests. 

The earlier test in the same class (`should encrypt traffic between selected services`) already makes an mTLS call to `echo2`, incrementing `mtls_match.total_match_count` to `1`. When the failing test runs afterward, its own mTLS call brings the counter to `2`, but the assertion was incorrectly expecting an absolute value of `1`.

### Fix

Snapshot both counters before making test requests, then assert that each counter increased by exactly `1` (a delta-based assertion) rather than checking for absolute values.